### PR TITLE
Pre release protagonist

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ will produce the following object (`result` variable):
 ```json
 {
   "ast": {
-    "_version": "2.1",
+    "_version": "3.0",
     "metadata": [],
     "name": "",
     "description": "",
@@ -112,7 +112,7 @@ will produce the following object (`result` variable):
 
 + `ast` ... This is the abstract syntax tree (AST) of the parsed blueprint.
 
-    The structure under this key is **1:1** with the [AST Blueprint serialization JSON media type v2.1](https://github.com/apiaryio/api-blueprint-ast#json-serialization) – `vnd.apiblueprint.ast.raw+json; version=2.1`.
+    The structure under this key is **1:1** with the [AST Blueprint serialization JSON media type v3.0](https://github.com/apiaryio/api-blueprint-ast#example-json-serialization) – `vnd.apiblueprint.ast.raw+json; version=3.0`.
 
 + `warnings` ... Array of the parser warnings as occurred during the parsing
     + `code` ...  Warning [group](https://github.com/apiaryio/snowcrash/blob/master/src/SourceAnnotation.h#L128) code

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "protagonist-experimental",
-  "version": "0.18.7",
+  "name": "protagonist",
+  "version": "0.19.0-rc",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",

--- a/src/parse.cc
+++ b/src/parse.cc
@@ -130,7 +130,7 @@ void AsyncParse(uv_work_t* request) {
     snowcrash::ParseResult<snowcrash::Blueprint> parseResult;
 
     // Parse the source data
-    drafter::parse_blueprint(baton->sourceData, baton->options, parseResult);
+    drafter::ParseBlueprint(baton->sourceData, baton->options, parseResult);
 
     baton->report = parseResult.report;
     baton->ast = parseResult.node;

--- a/test/ast-test.coffee
+++ b/test/ast-test.coffee
@@ -23,5 +23,5 @@ describe "Parser AST", ->
         done()
 
   # Parser AST should conform to AST serialization JSON media type
-  it '`ast` field conforms to `vnd.apiblueprint.ast.raw+json; version=2.1`', ->
+  it '`ast` field conforms to `vnd.apiblueprint.ast.raw+json; version=3.0`', ->
     assert.deepEqual ast_parsed, ast_parsed

--- a/test/fixtures/sample-api-ast.json
+++ b/test/fixtures/sample-api-ast.json
@@ -1,5 +1,5 @@
 {
-  "_version": "2.1",
+  "_version": "3.0",
   "metadata": [
     {
       "name": "FORMAT",

--- a/test/parser-ast-test.coffee
+++ b/test/parser-ast-test.coffee
@@ -34,9 +34,8 @@ describe 'Blueprint AST', ->
       it 'is defined', ->
         assert.isDefined ast._version
 
-      it 'is equal to 2.1', ->
-        # TODO: this should be 3.0!
-        assert.equal ast._version, '2.1'
+      it 'is equal to 3.0', ->
+        assert.equal ast._version, '3.0'
 
     describe 'metadata', ->
       it 'is defined', ->

--- a/test/performance/fixtures/fixture-1-ast.json
+++ b/test/performance/fixtures/fixture-1-ast.json
@@ -1,6 +1,6 @@
 {
   "ast": {
-    "_version": "2.1",
+    "_version": "3.0",
     "metadata": [
       {
         "name": "FORMAT",

--- a/test/performance/fixtures/fixture-2-ast.json
+++ b/test/performance/fixtures/fixture-2-ast.json
@@ -1,6 +1,6 @@
 {
   "ast": {
-    "_version": "2.1",
+    "_version": "3.0",
     "metadata": [],
     "name": "",
     "description": "",

--- a/test/sourcemap-test.coffee
+++ b/test/sourcemap-test.coffee
@@ -23,7 +23,5 @@ describe "Parser sourcemap", ->
         done()
 
   # Parser Sourcemap should conform to recent source map serialization JSON media type
-  it '`sourcemap` field conforms to `vnd.apiblueprint.sourcemap+json; version=2.1`', ->
-    # console.log JSON.stringify sourcemap_parsed, undefined, 2
-
+  it '`sourcemap` field conforms to `vnd.apiblueprint.sourcemap+json; version=3.0`', ->
     assert.deepEqual sourcemap_fixture, sourcemap_parsed


### PR DESCRIPTION
This PR updates drafter submodule which includes:

* Fixing the public API of drafter
* Updated AST and Parse Result versions

And this PR also includes a pre-release version of protagonist. `0.19.0-rc`. Please review & merge. Please do not publish the package to npm. I will do it as it needs a few settings to denote the package as pre-release.