### PR TITLE
added sync api

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ protagonist.parse('# My API', function(error, result) {
 });
 ```
 
+### Synchronous usage
+
+If you for some reason need to use the api synchronous, that is also possible.
+Please note that the recommended way is to use the asynchronous api as to not
+block the event loop.
+
+```js
+var result = protagonist.parseSync('# My API');
+```
+
 ### Parsing Result
 
 Parsing this blueprint:

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,7 +16,9 @@
       ],
       "sources": [
         "src/annotation.cc",
-        "src/parse.cc",
+        "src/options_parser.cc",
+        "src/parse_async.cc",
+        "src/parse_sync.cc",
         "src/protagonist.cc",
         "src/protagonist.h",
         "src/result.cc",

--- a/src/options_parser.cc
+++ b/src/options_parser.cc
@@ -1,0 +1,50 @@
+#include "protagonist.h"
+#include "snowcrash.h"
+
+using namespace v8;
+using namespace protagonist;
+
+//static const std::string RenderDescriptionsOptionKey = "renderDescriptions";
+static const std::string RequireBlueprintNameOptionKey = "requireBlueprintName";
+static const std::string ExportSourcemapOptionKey = "exportSourcemap";
+
+OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject) {
+    OptionsResult *optionsResult = (OptionsResult *) malloc(sizeof(OptionsResult));
+
+    optionsResult->options = 0;
+    optionsResult->error = NULL;
+
+    const Local<Array> properties = optionsObject->GetPropertyNames();
+    const uint32_t length = properties->Length();
+
+    for (uint32_t i = 0 ; i < length ; ++i) {
+        const Local<Value> key = properties->Get(i);
+        const Local<Value> value = optionsObject->Get(key);
+
+        if (RequireBlueprintNameOptionKey == *String::Utf8Value(key)) {
+            // RequireBlueprintNameOption
+            if (value->IsTrue())
+                optionsResult->options |= snowcrash::RequireBlueprintNameOption;
+            else
+                optionsResult->options &= snowcrash::RequireBlueprintNameOption;
+        }
+        else if (ExportSourcemapOptionKey == *String::Utf8Value(key)) {
+            // ExportSourcemapOption
+            if (value->IsTrue())
+                optionsResult->options |= snowcrash::ExportSourcemapOption;
+            else
+                optionsResult->options &= snowcrash::ExportSourcemapOption;
+        }
+        else {
+            // Unrecognized option
+            std::stringstream ss;
+            ss << "unrecognized option '" << *String::Utf8Value(key) << "', expected: ";
+            ss << "'" << RequireBlueprintNameOptionKey << "' or '" << ExportSourcemapOptionKey << "'";
+
+            optionsResult->error = ss.str().c_str();
+            return optionsResult;
+        }
+    }
+
+    return optionsResult;
+}

--- a/src/parse_sync.cc
+++ b/src/parse_sync.cc
@@ -1,0 +1,58 @@
+#include <string>
+#include <sstream>
+#include "protagonist.h"
+#include "snowcrash.h"
+#include "drafter.h"
+
+using std::string;
+using namespace v8;
+using namespace protagonist;
+
+NAN_METHOD(protagonist::ParseSync) {
+    NanScope();
+
+    // Check arguments
+    if (args.Length() != 1 && args.Length() != 2) {
+        NanThrowTypeError("wrong number of arguments, `parseSync(string, options)` expected");
+        NanReturnUndefined();
+    }
+
+    if (!args[0]->IsString()) {
+        NanThrowTypeError("wrong argument - string expected, `parseSync(string, options)`");
+        NanReturnUndefined();
+    }
+
+    if (args.Length() == 2 && !args[1]->IsObject()) {
+        NanThrowTypeError("wrong argument - object expected, `parseSync(string, options)`");
+        NanReturnUndefined();
+    }
+
+    // Get source data
+    String::Utf8Value sourceData(args[0]->ToString());
+
+    // Prepare options
+    snowcrash::BlueprintParserOptions options = 0;
+
+    if (args.Length() == 2) {
+        OptionsResult *optionsResult = ParseOptionsObject(Handle<Object>::Cast(args[1]));
+
+        if (optionsResult->error != NULL) {
+            NanThrowTypeError(optionsResult->error);
+            NanReturnUndefined();
+        }
+
+        options = optionsResult->options;
+        free(optionsResult);
+    }
+
+    // Parse the source data
+    snowcrash::ParseResult<snowcrash::Blueprint> parseResult;
+    drafter::ParseBlueprint(*sourceData, options, parseResult);
+
+    if (parseResult.report.error.code != snowcrash::Error::OK) {
+        NanThrowError(SourceAnnotation::WrapSourceAnnotation(parseResult.report.error));
+        NanReturnUndefined();
+    }
+
+    NanReturnValue(Result::WrapResult(parseResult.report, parseResult.node, parseResult.sourceMap, options));
+}

--- a/src/protagonist.cc
+++ b/src/protagonist.cc
@@ -13,6 +13,7 @@ void Init(Handle<Object> exports) {
 
     // Parse function
     exports->Set(NanNew<String>("parse"), NanNew<FunctionTemplate>(Parse)->GetFunction());
+    exports->Set(NanNew<String>("parseSync"), NanNew<FunctionTemplate>(ParseSync)->GetFunction());
 }
 
 NODE_MODULE(protagonist, Init)

--- a/src/protagonist.h
+++ b/src/protagonist.h
@@ -12,6 +12,16 @@
 namespace protagonist {
 
     //
+    // Options parsing
+    ///
+    struct OptionsResult {
+      snowcrash::BlueprintParserOptions options;
+      const char *error;
+    };
+
+    OptionsResult* ParseOptionsObject(v8::Handle<v8::Object>);
+
+    //
     // SourceAnnotation
     //
     class SourceAnnotation : public node::ObjectWrap {
@@ -55,6 +65,7 @@ namespace protagonist {
     // Parse function
     //
     extern NAN_METHOD(Parse);
+    extern NAN_METHOD(ParseSync);
 }
 
 #endif

--- a/test/fixtures/sample-api-ast.json
+++ b/test/fixtures/sample-api-ast.json
@@ -47,6 +47,10 @@
               "description": "",
               "method": "GET",
               "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
               "content": [],
               "examples": [
                 {
@@ -68,10 +72,7 @@
                       "content": [
                         {
                           "element": "dataStructure",
-                          "name": {
-                            "literal": "",
-                            "variable": false
-                          },
+                          "name": null,
                           "typeDefinition": {
                             "typeSpecification": {
                               "name": {
@@ -95,6 +96,10 @@
               "description": "",
               "method": "DELETE",
               "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
               "content": [],
               "examples": [
                 {
@@ -124,10 +129,7 @@
               },
               "typeDefinition": {
                 "typeSpecification": {
-                  "name": {
-                    "literal": "",
-                    "variable": false
-                  },
+                  "name": null,
                   "nestedTypes": []
                 },
                 "attributes": []
@@ -230,6 +232,10 @@
               "description": "",
               "method": "GET",
               "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
               "content": [],
               "examples": [
                 {
@@ -251,10 +257,7 @@
                       "content": [
                         {
                           "element": "dataStructure",
-                          "name": {
-                            "literal": "",
-                            "variable": false
-                          },
+                          "name": null,
                           "typeDefinition": {
                             "typeSpecification": {
                               "name": {
@@ -278,6 +281,10 @@
               "description": "",
               "method": "DELETE",
               "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
               "content": [],
               "examples": [
                 {
@@ -307,10 +314,7 @@
               },
               "typeDefinition": {
                 "typeSpecification": {
-                  "name": {
-                    "literal": "",
-                    "variable": false
-                  },
+                  "name": null,
                   "nestedTypes": []
                 },
                 "attributes": []

--- a/test/sync-test.coffee
+++ b/test/sync-test.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 {assert} = require 'chai'
 protagonist = require '../build/Release/protagonist'
 
-describe "Parser AST - Async", ->
+describe "Parser AST - Sync", ->
 
   ast_fixture = require './fixtures/sample-api-ast.json'
   ast_parsed = null
@@ -16,11 +16,8 @@ describe "Parser AST - Async", ->
     fs.readFile fixture_path, 'utf8', (err, data) ->
       return done err if err
 
-      protagonist.parse data, (err, result) ->
-        return done err if err
-
-        ast_parsed = result.ast
-        done()
+      ast_parsed = protagonist.parseSync(data).ast
+      done()
 
   # Parser AST should conform to AST serialization JSON media type
   it '`ast` field conforms to `vnd.apiblueprint.ast.raw+json; version=3.0`', ->


### PR DESCRIPTION
*Fixes #67*

This adds `parseSync` that parses on the main thread and returns the result.

It also fixes a previous existing test where it compared `result === result` instead of `result === expected`.