### PR TITLE
Update tests for MSON refract

### DIFF
--- a/test/fixtures/sample-api-ast.json
+++ b/test/fixtures/sample-api-ast.json
@@ -67,23 +67,52 @@
                           "value": "application/json"
                         }
                       ],
-                      "body": "",
+                      "body": "{\n  \"id\": 0,\n  \"message\": \"Hello World!\"\n}",
                       "schema": "",
                       "content": [
                         {
-                          "element": "dataStructure",
-                          "name": null,
-                          "typeDefinition": {
-                            "typeSpecification": {
-                              "name": {
-                                "literal": "Message",
-                                "variable": false
+                          "element": "extend",
+                          "content": [
+                            {
+                              "element": "object",
+                              "meta": {
+                                "ref": "Message"
                               },
-                              "nestedTypes": []
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "id"
+                                    },
+                                    "value": {
+                                      "element": "number"
+                                    }
+                                  }
+                                },
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "description": "The Message"
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "message"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "Hello World!"
+                                    }
+                                  }
+                                }
+                              ]
                             },
-                            "attributes": []
-                          },
-                          "sections": []
+                            {
+                              "element": "object"
+                            }
+                          ]
                         }
                       ]
                     }
@@ -122,68 +151,38 @@
           ],
           "content": [
             {
-              "element": "dataStructure",
-              "name": {
-                "literal": "Message",
-                "variable": false
+              "element": "object",
+              "meta": {
+                "id": "Message"
               },
-              "typeDefinition": {
-                "typeSpecification": {
-                  "name": null,
-                  "nestedTypes": []
-                },
-                "attributes": []
-              },
-              "sections": [
+              "content": [
                 {
-                  "class": "memberType",
-                  "content": [
-                    {
-                      "content": {
-                        "name": {
-                          "literal": "id"
-                        },
-                        "description": "",
-                        "valueDefinition": {
-                          "values": [],
-                          "typeDefinition": {
-                            "typeSpecification": {
-                              "name": "number",
-                              "nestedTypes": []
-                            },
-                            "attributes": []
-                          }
-                        },
-                        "sections": []
-                      },
-                      "class": "property"
+                  "element": "member",
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "id"
                     },
-                    {
-                      "content": {
-                        "name": {
-                          "literal": "message"
-                        },
-                        "description": "The Message",
-                        "valueDefinition": {
-                          "values": [
-                            {
-                              "literal": "Hello World!",
-                              "variable": false
-                            }
-                          ],
-                          "typeDefinition": {
-                            "typeSpecification": {
-                              "name": "string",
-                              "nestedTypes": []
-                            },
-                            "attributes": []
-                          }
-                        },
-                        "sections": []
-                      },
-                      "class": "property"
+                    "value": {
+                      "element": "number"
                     }
-                  ]
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "The Message"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "message"
+                    },
+                    "value": {
+                      "element": "string",
+                      "content": "Hello World!"
+                    }
+                  }
                 }
               ]
             }
@@ -252,23 +251,52 @@
                           "value": "application/json"
                         }
                       ],
-                      "body": "",
+                      "body": "{\n  \"id\": 0,\n  \"message\": \"Hello World!\"\n}",
                       "schema": "",
                       "content": [
                         {
-                          "element": "dataStructure",
-                          "name": null,
-                          "typeDefinition": {
-                            "typeSpecification": {
-                              "name": {
-                                "literal": "Message",
-                                "variable": false
+                          "element": "extend",
+                          "content": [
+                            {
+                              "element": "object",
+                              "meta": {
+                                "ref": "Message"
                               },
-                              "nestedTypes": []
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "id"
+                                    },
+                                    "value": {
+                                      "element": "number"
+                                    }
+                                  }
+                                },
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "description": "The Message"
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "message"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "Hello World!"
+                                    }
+                                  }
+                                }
+                              ]
                             },
-                            "attributes": []
-                          },
-                          "sections": []
+                            {
+                              "element": "object"
+                            }
+                          ]
                         }
                       ]
                     }
@@ -307,68 +335,38 @@
           ],
           "content": [
             {
-              "element": "dataStructure",
-              "name": {
-                "literal": "Message",
-                "variable": false
+              "element": "object",
+              "meta": {
+                "id": "Message"
               },
-              "typeDefinition": {
-                "typeSpecification": {
-                  "name": null,
-                  "nestedTypes": []
-                },
-                "attributes": []
-              },
-              "sections": [
+              "content": [
                 {
-                  "class": "memberType",
-                  "content": [
-                    {
-                      "content": {
-                        "name": {
-                          "literal": "id"
-                        },
-                        "description": "",
-                        "valueDefinition": {
-                          "values": [],
-                          "typeDefinition": {
-                            "typeSpecification": {
-                              "name": "number",
-                              "nestedTypes": []
-                            },
-                            "attributes": []
-                          }
-                        },
-                        "sections": []
-                      },
-                      "class": "property"
+                  "element": "member",
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "id"
                     },
-                    {
-                      "content": {
-                        "name": {
-                          "literal": "message"
-                        },
-                        "description": "The Message",
-                        "valueDefinition": {
-                          "values": [
-                            {
-                              "literal": "Hello World!",
-                              "variable": false
-                            }
-                          ],
-                          "typeDefinition": {
-                            "typeSpecification": {
-                              "name": "string",
-                              "nestedTypes": []
-                            },
-                            "attributes": []
-                          }
-                        },
-                        "sections": []
-                      },
-                      "class": "property"
+                    "value": {
+                      "element": "number"
                     }
-                  ]
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "The Message"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "message"
+                    },
+                    "value": {
+                      "element": "string",
+                      "content": "Hello World!"
+                    }
+                  }
                 }
               ]
             }

--- a/test/parser-mson-test.coffee
+++ b/test/parser-mson-test.coffee
@@ -1,151 +1,151 @@
 protagonist = require '../build/Release/protagonist'
 {assert} = require 'chai'
 
-describe 'MSON AST', ->
-  mson_ast = null
-
-  before (done) ->
-    source = '''
-    # Resource [/]
-    ## Action [GET]
-    + Response 200
-        + attribute
-            + message: Hello! (string) - The blog post article
-            + things: a, b, c, 1, 2 (array[string, number], required, fixed)
-            + choice
-                + One of
-                    + name
-                    + address
-            + mixin
-                + Include Person
-
-    # Data Structures
-    ## Person
-    '''
-
-    protagonist.parse source, (err, result) ->
-      return done err if err
-      mson_ast = result.ast.content[0].content[0].actions[0].examples[0].responses[0].content[0]
-
-      # For debugging puposes:
-      #console.log JSON.stringify mson_ast, undefined, 2
-
-      done()
-
-  describe 'Attributes named type', ->
-    it 'is defined', ->
-      assert.isDefined mson_ast
-
-    describe 'name', ->
-      it 'is defined', ->
-        assert.isDefined mson_ast.name
-
-    describe 'base', ->
-      it 'is undefined', ->
-        assert.isUndefined mson_ast.base
-
-    describe 'sections', ->
-      it 'is defined', ->
-        assert.isDefined mson_ast.sections
-
-      it 'has one member section', ->
-        assert.equal mson_ast.sections.length, 1
-
-  describe 'Attributes object type section', ->
-    member_ast = null
-
-    before ->
-      member_ast = mson_ast.sections[0]
-
-    it 'is defined', ->
-      assert.isDefined member_ast
-
-    describe 'class', ->
-      it 'is defined', ->
-        assert.isDefined member_ast.class
-
-      it 'is of "memberType" class', ->
-        assert.equal member_ast.class, 'memberType'
-
-    describe 'content', ->
-      it 'is defined', ->
-        assert.isDefined member_ast.content
-
-      it 'has four member section', ->
-        assert.equal member_ast.content.length, 4
-
-    describe 'member type', ->
-      member_type_ast = null
-
-      before ->
-        member_type_ast = member_ast.content[0]
-
-      it 'is defined', ->
-        assert.isDefined member_type_ast
-
-      describe 'class', ->
-        it 'is defined', ->
-          assert.isDefined member_type_ast.class
-
-        it 'is of "property" class', ->
-          assert.equal member_type_ast.class, 'property'
-
-      describe 'content', ->
-        it 'is defined', ->
-          assert.isDefined member_type_ast.content
-
-      describe 'property member', ->
-        property_member_ast = null
-
-        before ->
-          property_member_ast = member_type_ast.content
-
-        describe 'name', ->
-          it 'is defined', ->
-            assert.isDefined property_member_ast.name
-
-          it 'literal value is "messsage"', ->
-            assert.equal property_member_ast.name.literal, 'message'
- 
-        describe 'description', ->
-          it 'is defined', ->
-            assert.isDefined property_member_ast.description
-          
-          it 'value is "The blog post article"', ->
-            assert.equal property_member_ast.description, 'The blog post article'
-
-        describe 'value definition', ->
-          it 'is defined', ->
-            assert.isDefined property_member_ast.valueDefinition
-
-          describe 'values', ->
-            it 'is defined', ->
-              assert.isDefined property_member_ast.valueDefinition.values
-
-            it 'has one value', ->
-              assert.equal property_member_ast.valueDefinition.values.length, 1
-
-            describe 'value', ->
-              it 'is defined', ->
-                assert.isDefined property_member_ast.valueDefinition.values[0]
-
-              it 'literal value is "Hello!"', ->
-                assert.equal property_member_ast.valueDefinition.values[0].literal, 'Hello!'
-
-              it 'is not variable', ->
-                assert.equal property_member_ast.valueDefinition.values[0].variable, false
-          
-          describe 'type definition', ->
-            it 'is defined', ->
-              assert.isDefined property_member_ast.valueDefinition.typeDefinition
-
-            describe 'type specification', ->
-              it 'is defined', ->
-                assert.isDefined property_member_ast.valueDefinition.typeDefinition.typeSpecification
-
-              describe 'type name', ->
-                it 'is defined', ->
-                  assert.isDefined property_member_ast.valueDefinition.typeDefinition.typeSpecification.name
-
-                it 'is of "string" type', ->
-                  assert.equal property_member_ast.valueDefinition.typeDefinition.typeSpecification.name, 'string'
+# describe 'MSON AST', ->
+#   mson_ast = null
+#
+#   before (done) ->
+#     source = '''
+#     # Resource [/]
+#     ## Action [GET]
+#     + Response 200
+#         + attribute
+#             + message: Hello! (string) - The blog post article
+#             + things: a, b, c, 1, 2 (array[string, number], required, fixed)
+#             + choice
+#                 + One of
+#                     + name
+#                     + address
+#             + mixin
+#                 + Include Person
+#
+#     # Data Structures
+#     ## Person
+#     '''
+#
+#     protagonist.parse source, (err, result) ->
+#       return done err if err
+#       mson_ast = result.ast.content[0].content[0].actions[0].examples[0].responses[0].content[0]
+#
+#       # For debugging puposes:
+#       #console.log JSON.stringify mson_ast, undefined, 2
+#
+#       done()
+#
+#   describe 'Attributes named type', ->
+#     it 'is defined', ->
+#       assert.isDefined mson_ast
+#
+#     describe 'name', ->
+#       it 'is defined', ->
+#         assert.isDefined mson_ast.name
+#
+#     describe 'base', ->
+#       it 'is undefined', ->
+#         assert.isUndefined mson_ast.base
+#
+#     describe 'sections', ->
+#       it 'is defined', ->
+#         assert.isDefined mson_ast.sections
+#
+#       it 'has one member section', ->
+#         assert.equal mson_ast.sections.length, 1
+#
+#   describe 'Attributes object type section', ->
+#     member_ast = null
+#
+#     before ->
+#       member_ast = mson_ast.sections[0]
+#
+#     it 'is defined', ->
+#       assert.isDefined member_ast
+#
+#     describe 'class', ->
+#       it 'is defined', ->
+#         assert.isDefined member_ast.class
+#
+#       it 'is of "memberType" class', ->
+#         assert.equal member_ast.class, 'memberType'
+#
+#     describe 'content', ->
+#       it 'is defined', ->
+#         assert.isDefined member_ast.content
+#
+#       it 'has four member section', ->
+#         assert.equal member_ast.content.length, 4
+#
+#     describe 'member type', ->
+#       member_type_ast = null
+#
+#       before ->
+#         member_type_ast = member_ast.content[0]
+#
+#       it 'is defined', ->
+#         assert.isDefined member_type_ast
+#
+#       describe 'class', ->
+#         it 'is defined', ->
+#           assert.isDefined member_type_ast.class
+#
+#         it 'is of "property" class', ->
+#           assert.equal member_type_ast.class, 'property'
+#
+#       describe 'content', ->
+#         it 'is defined', ->
+#           assert.isDefined member_type_ast.content
+#
+#       describe 'property member', ->
+#         property_member_ast = null
+#
+#         before ->
+#           property_member_ast = member_type_ast.content
+#
+#         describe 'name', ->
+#           it 'is defined', ->
+#             assert.isDefined property_member_ast.name
+#
+#           it 'literal value is "messsage"', ->
+#             assert.equal property_member_ast.name.literal, 'message'
+#
+#         describe 'description', ->
+#           it 'is defined', ->
+#             assert.isDefined property_member_ast.description
+#
+#           it 'value is "The blog post article"', ->
+#             assert.equal property_member_ast.description, 'The blog post article'
+#
+#         describe 'value definition', ->
+#           it 'is defined', ->
+#             assert.isDefined property_member_ast.valueDefinition
+#
+#           describe 'values', ->
+#             it 'is defined', ->
+#               assert.isDefined property_member_ast.valueDefinition.values
+#
+#             it 'has one value', ->
+#               assert.equal property_member_ast.valueDefinition.values.length, 1
+#
+#             describe 'value', ->
+#               it 'is defined', ->
+#                 assert.isDefined property_member_ast.valueDefinition.values[0]
+#
+#               it 'literal value is "Hello!"', ->
+#                 assert.equal property_member_ast.valueDefinition.values[0].literal, 'Hello!'
+#
+#               it 'is not variable', ->
+#                 assert.equal property_member_ast.valueDefinition.values[0].variable, false
+#
+#           describe 'type definition', ->
+#             it 'is defined', ->
+#               assert.isDefined property_member_ast.valueDefinition.typeDefinition
+#
+#             describe 'type specification', ->
+#               it 'is defined', ->
+#                 assert.isDefined property_member_ast.valueDefinition.typeDefinition.typeSpecification
+#
+#               describe 'type name', ->
+#                 it 'is defined', ->
+#                   assert.isDefined property_member_ast.valueDefinition.typeDefinition.typeSpecification.name
+#
+#                 it 'is of "string" type', ->
+#                   assert.equal property_member_ast.valueDefinition.typeDefinition.typeSpecification.name, 'string'

--- a/test/parser-mson-test.coffee
+++ b/test/parser-mson-test.coffee
@@ -1,151 +1,51 @@
 protagonist = require '../build/Release/protagonist'
 {assert} = require 'chai'
 
-# describe 'MSON AST', ->
-#   mson_ast = null
-#
-#   before (done) ->
-#     source = '''
-#     # Resource [/]
-#     ## Action [GET]
-#     + Response 200
-#         + attribute
-#             + message: Hello! (string) - The blog post article
-#             + things: a, b, c, 1, 2 (array[string, number], required, fixed)
-#             + choice
-#                 + One of
-#                     + name
-#                     + address
-#             + mixin
-#                 + Include Person
-#
-#     # Data Structures
-#     ## Person
-#     '''
-#
-#     protagonist.parse source, (err, result) ->
-#       return done err if err
-#       mson_ast = result.ast.content[0].content[0].actions[0].examples[0].responses[0].content[0]
-#
-#       # For debugging puposes:
-#       #console.log JSON.stringify mson_ast, undefined, 2
-#
-#       done()
-#
-#   describe 'Attributes named type', ->
-#     it 'is defined', ->
-#       assert.isDefined mson_ast
-#
-#     describe 'name', ->
-#       it 'is defined', ->
-#         assert.isDefined mson_ast.name
-#
-#     describe 'base', ->
-#       it 'is undefined', ->
-#         assert.isUndefined mson_ast.base
-#
-#     describe 'sections', ->
-#       it 'is defined', ->
-#         assert.isDefined mson_ast.sections
-#
-#       it 'has one member section', ->
-#         assert.equal mson_ast.sections.length, 1
-#
-#   describe 'Attributes object type section', ->
-#     member_ast = null
-#
-#     before ->
-#       member_ast = mson_ast.sections[0]
-#
-#     it 'is defined', ->
-#       assert.isDefined member_ast
-#
-#     describe 'class', ->
-#       it 'is defined', ->
-#         assert.isDefined member_ast.class
-#
-#       it 'is of "memberType" class', ->
-#         assert.equal member_ast.class, 'memberType'
-#
-#     describe 'content', ->
-#       it 'is defined', ->
-#         assert.isDefined member_ast.content
-#
-#       it 'has four member section', ->
-#         assert.equal member_ast.content.length, 4
-#
-#     describe 'member type', ->
-#       member_type_ast = null
-#
-#       before ->
-#         member_type_ast = member_ast.content[0]
-#
-#       it 'is defined', ->
-#         assert.isDefined member_type_ast
-#
-#       describe 'class', ->
-#         it 'is defined', ->
-#           assert.isDefined member_type_ast.class
-#
-#         it 'is of "property" class', ->
-#           assert.equal member_type_ast.class, 'property'
-#
-#       describe 'content', ->
-#         it 'is defined', ->
-#           assert.isDefined member_type_ast.content
-#
-#       describe 'property member', ->
-#         property_member_ast = null
-#
-#         before ->
-#           property_member_ast = member_type_ast.content
-#
-#         describe 'name', ->
-#           it 'is defined', ->
-#             assert.isDefined property_member_ast.name
-#
-#           it 'literal value is "messsage"', ->
-#             assert.equal property_member_ast.name.literal, 'message'
-#
-#         describe 'description', ->
-#           it 'is defined', ->
-#             assert.isDefined property_member_ast.description
-#
-#           it 'value is "The blog post article"', ->
-#             assert.equal property_member_ast.description, 'The blog post article'
-#
-#         describe 'value definition', ->
-#           it 'is defined', ->
-#             assert.isDefined property_member_ast.valueDefinition
-#
-#           describe 'values', ->
-#             it 'is defined', ->
-#               assert.isDefined property_member_ast.valueDefinition.values
-#
-#             it 'has one value', ->
-#               assert.equal property_member_ast.valueDefinition.values.length, 1
-#
-#             describe 'value', ->
-#               it 'is defined', ->
-#                 assert.isDefined property_member_ast.valueDefinition.values[0]
-#
-#               it 'literal value is "Hello!"', ->
-#                 assert.equal property_member_ast.valueDefinition.values[0].literal, 'Hello!'
-#
-#               it 'is not variable', ->
-#                 assert.equal property_member_ast.valueDefinition.values[0].variable, false
-#
-#           describe 'type definition', ->
-#             it 'is defined', ->
-#               assert.isDefined property_member_ast.valueDefinition.typeDefinition
-#
-#             describe 'type specification', ->
-#               it 'is defined', ->
-#                 assert.isDefined property_member_ast.valueDefinition.typeDefinition.typeSpecification
-#
-#               describe 'type name', ->
-#                 it 'is defined', ->
-#                   assert.isDefined property_member_ast.valueDefinition.typeDefinition.typeSpecification.name
-#
-#                 it 'is of "string" type', ->
-#                   assert.equal property_member_ast.valueDefinition.typeDefinition.typeSpecification.name, 'string'
+describe 'MSON Refract', ->
+  attributes = null
+  dataStructures = null
+
+  before (done) ->
+    source = '''
+    # Resource [/]
+    ## Action [GET]
+    + Response 200
+        + Attributes
+            + id
+
+    # Data Structures
+    ## Person
+    + name
+    '''
+
+    protagonist.parse source, (err, result) ->
+      return done err if err
+      attributes = result.ast.content[0].content[0].actions[0].examples[0].responses[0].content[0]
+      dataStructures = result.ast.content[1].content
+      done()
+
+  describe 'Attributes', ->
+    it 'are defined', ->
+      assert.isDefined attributes
+
+    it 'are an object', ->
+      assert.equal attributes.element, 'object'
+
+    it 'object has a single member', ->
+      assert.equal attributes.content.length, 1
+
+    it 'member is `id`', ->
+      assert.equal attributes.content[0].content.key.content, 'id'
+
+  describe 'Data structures', ->
+    it 'are defined', ->
+      assert.isDefined dataStructures
+
+    it 'have one item', ->
+      assert.equal dataStructures.length, 1
+
+    it 'item is a `Person` structure', ->
+      assert.equal dataStructures[0].meta.id, 'Person'
+
+    it 'Person has a `name` member', ->
+      assert.equal dataStructures[0].content[0].content.key.content, 'name'


### PR DESCRIPTION
This fixes the currently-failing tests in the `shared/refract` branch by updating the fixture to use MSON refract and commenting out some MSON-AST specific tests that will need to be updated in the future.
