### PR TITLE
Expose a type option to select refract or ast output

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ block the event loop.
 var result = protagonist.parseSync('# My API');
 ```
 
+### Parsing Options
+
+Options can be passed to the parser as an optional second argument to both the asynchronous and synchronous interfaces:
+
+```js
+var options = {
+    exportSourcemap: true
+}
+protagonist.parse('# My API', options, callback);
+```
+
+The available options are:
+
+Name                   | Description
+---------------------- | ----------------------------------------------------------
+`requireBlueprintName` | Require that the API Blueprint have a title
+`exportSourcemap`      | Enable sourcemap generation
+`type`                 | Set the output structure type as either `ast` or `refract`.
+
 ### Parsing Result
 
 Parsing this blueprint:

--- a/src/options_parser.cc
+++ b/src/options_parser.cc
@@ -7,6 +7,10 @@ using namespace protagonist;
 //static const std::string RenderDescriptionsOptionKey = "renderDescriptions";
 static const std::string RequireBlueprintNameOptionKey = "requireBlueprintName";
 static const std::string ExportSourcemapOptionKey = "exportSourcemap";
+static const std::string TypeOptionKey = "type";
+
+static const std::string TypeOptionAst = "ast";
+static const std::string TypeOptionRefract = "refract";
 
 OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject) {
     OptionsResult *optionsResult = (OptionsResult *) malloc(sizeof(OptionsResult));
@@ -35,11 +39,30 @@ OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject) {
             else
                 optionsResult->options &= snowcrash::ExportSourcemapOption;
         }
+        else if (TypeOptionKey == *String::Utf8Value(key)) {
+            // TypeOption
+            char *strValue = *String::Utf8Value(value);
+            if (TypeOptionAst == strValue) {
+                // TODO
+                // optionsResult->options &= snowcrash::TypeOptionAst;
+            } else if (TypeOptionRefract == strValue) {
+                // TODO
+                // optionsResult->options &= snowcrash::TypeOptionRefract;
+            } else {
+                std::stringstream ss;
+                ss << "unrecognized type '" << strValue << "', expected '";
+                ss << TypeOptionAst << "' or '" << TypeOptionRefract << "'";
+
+                optionsResult->error = ss.str().c_str();
+                return optionsResult;
+            }
+        }
         else {
             // Unrecognized option
             std::stringstream ss;
             ss << "unrecognized option '" << *String::Utf8Value(key) << "', expected: ";
-            ss << "'" << RequireBlueprintNameOptionKey << "' or '" << ExportSourcemapOptionKey << "'";
+            ss << "'" << RequireBlueprintNameOptionKey << "', '";
+            ss << ExportSourcemapOptionKey << "' or '" << TypeOptionKey << '"';
 
             optionsResult->error = ss.str().c_str();
             return optionsResult;

--- a/src/options_parser.cc
+++ b/src/options_parser.cc
@@ -26,29 +26,33 @@ OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject) {
         const Local<Value> key = properties->Get(i);
         const Local<Value> value = optionsObject->Get(key);
 
-        if (RequireBlueprintNameOptionKey == *String::Utf8Value(key)) {
+        const String::Utf8Value strKey(key);
+
+        if (RequireBlueprintNameOptionKey == *strKey) {
             // RequireBlueprintNameOption
             if (value->IsTrue())
                 optionsResult->options |= snowcrash::RequireBlueprintNameOption;
             else
                 optionsResult->options &= snowcrash::RequireBlueprintNameOption;
         }
-        else if (ExportSourcemapOptionKey == *String::Utf8Value(key)) {
+        else if (ExportSourcemapOptionKey == *strKey) {
             // ExportSourcemapOption
             if (value->IsTrue())
                 optionsResult->options |= snowcrash::ExportSourcemapOption;
             else
                 optionsResult->options &= snowcrash::ExportSourcemapOption;
         }
-        else if (TypeOptionKey == *String::Utf8Value(key)) {
+        else if (TypeOptionKey == *strKey) {
             // TypeOption
-            if (TypeOptionAst == *String::Utf8Value(value)) {
+            const String::Utf8Value strValue(value);
+
+            if (TypeOptionAst == *strValue) {
                 optionsResult->astType = drafter::NormalASTType;
-            } else if (TypeOptionRefract == *String::Utf8Value(value)) {
+            } else if (TypeOptionRefract == *strValue) {
                 optionsResult->astType = drafter::RefractASTType;
             } else {
                 std::stringstream ss;
-                ss << "unrecognized type '" << *String::Utf8Value(value) << "', expected '";
+                ss << "unrecognized type '" << *strValue << "', expected '";
                 ss << TypeOptionAst << "' or '" << TypeOptionRefract << "'";
 
                 optionsResult->error = ss.str().c_str();
@@ -58,7 +62,7 @@ OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject) {
         else {
             // Unrecognized option
             std::stringstream ss;
-            ss << "unrecognized option '" << *String::Utf8Value(key) << "', expected: ";
+            ss << "unrecognized option '" << *strKey << "', expected: ";
             ss << "'" << RequireBlueprintNameOptionKey << "', '";
             ss << ExportSourcemapOptionKey << "' or '" << TypeOptionKey << '"';
 

--- a/src/options_parser.cc
+++ b/src/options_parser.cc
@@ -41,7 +41,7 @@ OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject) {
         }
         else if (TypeOptionKey == *String::Utf8Value(key)) {
             // TypeOption
-            char *strValue = *String::Utf8Value(value);
+            const char *strValue = *String::Utf8Value(value);
             if (TypeOptionAst == strValue) {
                 // TODO
                 // optionsResult->options &= snowcrash::TypeOptionAst;

--- a/src/options_parser.cc
+++ b/src/options_parser.cc
@@ -16,6 +16,7 @@ OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject) {
     OptionsResult *optionsResult = (OptionsResult *) malloc(sizeof(OptionsResult));
 
     optionsResult->options = 0;
+    optionsResult->astType = drafter::RefractASTType;
     optionsResult->error = NULL;
 
     const Local<Array> properties = optionsObject->GetPropertyNames();
@@ -43,11 +44,9 @@ OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject) {
             // TypeOption
             const char *strValue = *String::Utf8Value(value);
             if (TypeOptionAst == strValue) {
-                // TODO
-                // optionsResult->options &= snowcrash::TypeOptionAst;
+                optionsResult->astType = drafter::NormalASTType;
             } else if (TypeOptionRefract == strValue) {
-                // TODO
-                // optionsResult->options &= snowcrash::TypeOptionRefract;
+                optionsResult->astType = drafter::RefractASTType;
             } else {
                 std::stringstream ss;
                 ss << "unrecognized type '" << strValue << "', expected '";

--- a/src/options_parser.cc
+++ b/src/options_parser.cc
@@ -42,14 +42,13 @@ OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject) {
         }
         else if (TypeOptionKey == *String::Utf8Value(key)) {
             // TypeOption
-            const char *strValue = *String::Utf8Value(value);
-            if (TypeOptionAst == strValue) {
+            if (TypeOptionAst == *String::Utf8Value(value)) {
                 optionsResult->astType = drafter::NormalASTType;
-            } else if (TypeOptionRefract == strValue) {
+            } else if (TypeOptionRefract == *String::Utf8Value(value)) {
                 optionsResult->astType = drafter::RefractASTType;
             } else {
                 std::stringstream ss;
-                ss << "unrecognized type '" << strValue << "', expected '";
+                ss << "unrecognized type '" << *String::Utf8Value(value) << "', expected '";
                 ss << TypeOptionAst << "' or '" << TypeOptionRefract << "'";
 
                 optionsResult->error = ss.str().c_str();

--- a/src/parse_async.cc
+++ b/src/parse_async.cc
@@ -22,6 +22,7 @@ struct Baton {
 
     // Input
     snowcrash::BlueprintParserOptions options;
+    drafter::ASTType astType;
     mdp::ByteBuffer sourceData;
 
     // Output
@@ -61,6 +62,7 @@ NAN_METHOD(protagonist::Parse) {
 
     // Prepare options
     snowcrash::BlueprintParserOptions options = 0;
+    drafter::ASTType astType = drafter::RefractASTType;
 
     if (args.Length() == 3) {
         OptionsResult *optionsResult = ParseOptionsObject(Handle<Object>::Cast(args[1]));
@@ -71,6 +73,7 @@ NAN_METHOD(protagonist::Parse) {
         }
 
         options = optionsResult->options;
+        astType = optionsResult->astType;
         free(optionsResult);
     }
 
@@ -80,6 +83,7 @@ NAN_METHOD(protagonist::Parse) {
     // Prepare threadpool baton
     Baton* baton = ::new Baton();
     baton->options = options;
+    baton->astType = astType;
     baton->sourceData = *sourceData;
     NanAssignPersistent<Function>(baton->callback, callback);
 
@@ -124,7 +128,7 @@ void AsyncParseAfter(uv_work_t* request) {
     else
         argv[0] = SourceAnnotation::WrapSourceAnnotation(baton->report.error);
 
-    argv[1] = Result::WrapResult(baton->report, baton->ast, baton->sourcemap, baton->options);
+    argv[1] = Result::WrapResult(baton->report, baton->ast, baton->sourcemap, baton->options, baton->astType);
 
     TryCatch try_catch;
     Local<Function> callback = NanNew<Function>(baton->callback);

--- a/src/parse_sync.cc
+++ b/src/parse_sync.cc
@@ -56,5 +56,5 @@ NAN_METHOD(protagonist::ParseSync) {
         NanReturnUndefined();
     }
 
-    NanReturnValue(Result::WrapResult(parseResult.report, parseResult.node, parseResult.sourceMap, options, astType));
+    NanReturnValue(Result::WrapResult(parseResult, options, astType));
 }

--- a/src/parse_sync.cc
+++ b/src/parse_sync.cc
@@ -32,6 +32,7 @@ NAN_METHOD(protagonist::ParseSync) {
 
     // Prepare options
     snowcrash::BlueprintParserOptions options = 0;
+    drafter::ASTType astType = drafter::RefractASTType;
 
     if (args.Length() == 2) {
         OptionsResult *optionsResult = ParseOptionsObject(Handle<Object>::Cast(args[1]));
@@ -42,6 +43,7 @@ NAN_METHOD(protagonist::ParseSync) {
         }
 
         options = optionsResult->options;
+        astType = optionsResult->astType;
         free(optionsResult);
     }
 
@@ -54,5 +56,5 @@ NAN_METHOD(protagonist::ParseSync) {
         NanReturnUndefined();
     }
 
-    NanReturnValue(Result::WrapResult(parseResult.report, parseResult.node, parseResult.sourceMap, options));
+    NanReturnValue(Result::WrapResult(parseResult.report, parseResult.node, parseResult.sourceMap, options, astType));
 }

--- a/src/protagonist.h
+++ b/src/protagonist.h
@@ -8,6 +8,7 @@
 #include "BlueprintSourcemap.h"
 #include "SectionParserData.h"
 #include "Serialize.h"
+#include "SerializeResult.h"
 #include "SourceAnnotation.h"
 
 namespace protagonist {
@@ -50,9 +51,7 @@ namespace protagonist {
 
         // Wraps snowcrash::Warnings and snowcrash:Blueprint into report object
         // Note: snowcrash::Result::Error is being sent separately as Error object
-        static v8::Local<v8::Object> WrapResult(const snowcrash::Report& report,
-                                                const snowcrash::Blueprint& blueprint,
-                                                const snowcrash::SourceMap<snowcrash::Blueprint>& sourcemap,
+        static v8::Local<v8::Object> WrapResult(const snowcrash::ParseResult<snowcrash::Blueprint>& parseResult,
                                                 const snowcrash::BlueprintParserOptions& options,
                                                 const drafter::ASTType& astType);
 

--- a/src/protagonist.h
+++ b/src/protagonist.h
@@ -4,9 +4,6 @@
 #include <node.h>
 #include <v8.h>
 #include "nan.h"
-#include "Blueprint.h"
-#include "BlueprintSourcemap.h"
-#include "SectionParserData.h"
 #include "Serialize.h"
 #include "SerializeResult.h"
 #include "SourceAnnotation.h"

--- a/src/protagonist.h
+++ b/src/protagonist.h
@@ -7,6 +7,7 @@
 #include "Blueprint.h"
 #include "BlueprintSourcemap.h"
 #include "SectionParserData.h"
+#include "Serialize.h"
 #include "SourceAnnotation.h"
 
 namespace protagonist {
@@ -16,6 +17,7 @@ namespace protagonist {
     ///
     struct OptionsResult {
       snowcrash::BlueprintParserOptions options;
+      drafter::ASTType astType;
       const char *error;
     };
 
@@ -51,7 +53,8 @@ namespace protagonist {
         static v8::Local<v8::Object> WrapResult(const snowcrash::Report& report,
                                                 const snowcrash::Blueprint& blueprint,
                                                 const snowcrash::SourceMap<snowcrash::Blueprint>& sourcemap,
-                                                const snowcrash::BlueprintParserOptions& options);
+                                                const snowcrash::BlueprintParserOptions& options,
+                                                const drafter::ASTType& astType);
 
     private:
         Result();

--- a/src/result.cc
+++ b/src/result.cc
@@ -41,7 +41,8 @@ NAN_METHOD(Result::New)
 v8::Local<v8::Object> Result::WrapResult(const snowcrash::Report& report,
                                          const snowcrash::Blueprint& blueprint,
                                          const snowcrash::SourceMap<snowcrash::Blueprint>& sourcemap,
-                                         const snowcrash::BlueprintParserOptions& options)
+                                         const snowcrash::BlueprintParserOptions& options,
+                                         const drafter::ASTType& astType)
 {
     Local<Function> cons = NanNew<Function>(constructor);
     Local<Object> resultWrap = cons->NewInstance();
@@ -51,7 +52,7 @@ v8::Local<v8::Object> Result::WrapResult(const snowcrash::Report& report,
     static const char* SourcemapKey = "sourcemap";
 
     if (report.error.code == snowcrash::Error::OK) {
-        sos::Object blueprintSerializationWrap = drafter::WrapBlueprint(blueprint);
+        sos::Object blueprintSerializationWrap = drafter::WrapBlueprint(blueprint, astType);
 
         resultWrap->Set(NanNew<String>(AstKey), v8_wrap(blueprintSerializationWrap));
     }

--- a/test/ast-test.coffee
+++ b/test/ast-test.coffee
@@ -16,7 +16,7 @@ describe "Parser AST - Async", ->
     fs.readFile fixture_path, 'utf8', (err, data) ->
       return done err if err
 
-      protagonist.parse data, (err, result) ->
+      protagonist.parse data, type: 'ast', (err, result) ->
         return done err if err
 
         ast_parsed = result.ast

--- a/test/fixtures/sample-api-ast.json
+++ b/test/fixtures/sample-api-ast.json
@@ -74,48 +74,7 @@
                           "element": "dataStructure",
                           "content": [
                             {
-                              "element": "extend",
-                              "content": [
-                                {
-                                  "element": "object",
-                                  "meta": {
-                                    "ref": "Message"
-                                  },
-                                  "content": [
-                                    {
-                                      "element": "member",
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "id"
-                                        },
-                                        "value": {
-                                          "element": "number"
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "element": "member",
-                                      "meta": {
-                                        "description": "The Message"
-                                      },
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "message"
-                                        },
-                                        "value": {
-                                          "element": "string",
-                                          "content": "Hello World!"
-                                        }
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "element": "object"
-                                }
-                              ]
+                              "element": "Message"
                             }
                           ]
                         }
@@ -268,48 +227,7 @@
                           "element": "dataStructure",
                           "content": [
                             {
-                              "element": "extend",
-                              "content": [
-                                {
-                                  "element": "object",
-                                  "meta": {
-                                    "ref": "Message"
-                                  },
-                                  "content": [
-                                    {
-                                      "element": "member",
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "id"
-                                        },
-                                        "value": {
-                                          "element": "number"
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "element": "member",
-                                      "meta": {
-                                        "description": "The Message"
-                                      },
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "message"
-                                        },
-                                        "value": {
-                                          "element": "string",
-                                          "content": "Hello World!"
-                                        }
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "element": "object"
-                                }
-                              ]
+                              "element": "Message"
                             }
                           ]
                         }

--- a/test/fixtures/sample-api-ast.json
+++ b/test/fixtures/sample-api-ast.json
@@ -71,46 +71,51 @@
                       "schema": "",
                       "content": [
                         {
-                          "element": "extend",
+                          "element": "dataStructure",
                           "content": [
                             {
-                              "element": "object",
-                              "meta": {
-                                "ref": "Message"
-                              },
+                              "element": "extend",
                               "content": [
                                 {
-                                  "element": "member",
-                                  "content": {
-                                    "key": {
-                                      "element": "string",
-                                      "content": "id"
+                                  "element": "object",
+                                  "meta": {
+                                    "ref": "Message"
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "id"
+                                        },
+                                        "value": {
+                                          "element": "number"
+                                        }
+                                      }
                                     },
-                                    "value": {
-                                      "element": "number"
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "description": "The Message"
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "message"
+                                        },
+                                        "value": {
+                                          "element": "string",
+                                          "content": "Hello World!"
+                                        }
+                                      }
                                     }
-                                  }
+                                  ]
                                 },
                                 {
-                                  "element": "member",
-                                  "meta": {
-                                    "description": "The Message"
-                                  },
-                                  "content": {
-                                    "key": {
-                                      "element": "string",
-                                      "content": "message"
-                                    },
-                                    "value": {
-                                      "element": "string",
-                                      "content": "Hello World!"
-                                    }
-                                  }
+                                  "element": "object"
                                 }
                               ]
-                            },
-                            {
-                              "element": "object"
                             }
                           ]
                         }
@@ -151,38 +156,43 @@
           ],
           "content": [
             {
-              "element": "object",
-              "meta": {
-                "id": "Message"
-              },
+              "element": "dataStructure",
               "content": [
                 {
-                  "element": "member",
-                  "content": {
-                    "key": {
-                      "element": "string",
-                      "content": "id"
-                    },
-                    "value": {
-                      "element": "number"
-                    }
-                  }
-                },
-                {
-                  "element": "member",
+                  "element": "object",
                   "meta": {
-                    "description": "The Message"
+                    "id": "Message"
                   },
-                  "content": {
-                    "key": {
-                      "element": "string",
-                      "content": "message"
+                  "content": [
+                    {
+                      "element": "member",
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "id"
+                        },
+                        "value": {
+                          "element": "number"
+                        }
+                      }
                     },
-                    "value": {
-                      "element": "string",
-                      "content": "Hello World!"
+                    {
+                      "element": "member",
+                      "meta": {
+                        "description": "The Message"
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "message"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "Hello World!"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               ]
             }
@@ -255,46 +265,51 @@
                       "schema": "",
                       "content": [
                         {
-                          "element": "extend",
+                          "element": "dataStructure",
                           "content": [
                             {
-                              "element": "object",
-                              "meta": {
-                                "ref": "Message"
-                              },
+                              "element": "extend",
                               "content": [
                                 {
-                                  "element": "member",
-                                  "content": {
-                                    "key": {
-                                      "element": "string",
-                                      "content": "id"
+                                  "element": "object",
+                                  "meta": {
+                                    "ref": "Message"
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "id"
+                                        },
+                                        "value": {
+                                          "element": "number"
+                                        }
+                                      }
                                     },
-                                    "value": {
-                                      "element": "number"
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "description": "The Message"
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "message"
+                                        },
+                                        "value": {
+                                          "element": "string",
+                                          "content": "Hello World!"
+                                        }
+                                      }
                                     }
-                                  }
+                                  ]
                                 },
                                 {
-                                  "element": "member",
-                                  "meta": {
-                                    "description": "The Message"
-                                  },
-                                  "content": {
-                                    "key": {
-                                      "element": "string",
-                                      "content": "message"
-                                    },
-                                    "value": {
-                                      "element": "string",
-                                      "content": "Hello World!"
-                                    }
-                                  }
+                                  "element": "object"
                                 }
                               ]
-                            },
-                            {
-                              "element": "object"
                             }
                           ]
                         }
@@ -335,38 +350,43 @@
           ],
           "content": [
             {
-              "element": "object",
-              "meta": {
-                "id": "Message"
-              },
+              "element": "dataStructure",
               "content": [
                 {
-                  "element": "member",
-                  "content": {
-                    "key": {
-                      "element": "string",
-                      "content": "id"
-                    },
-                    "value": {
-                      "element": "number"
-                    }
-                  }
-                },
-                {
-                  "element": "member",
+                  "element": "object",
                   "meta": {
-                    "description": "The Message"
+                    "id": "Message"
                   },
-                  "content": {
-                    "key": {
-                      "element": "string",
-                      "content": "message"
+                  "content": [
+                    {
+                      "element": "member",
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "id"
+                        },
+                        "value": {
+                          "element": "number"
+                        }
+                      }
                     },
-                    "value": {
-                      "element": "string",
-                      "content": "Hello World!"
+                    {
+                      "element": "member",
+                      "meta": {
+                        "description": "The Message"
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "message"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "Hello World!"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               ]
             }

--- a/test/fixtures/sample-api-refract.json
+++ b/test/fixtures/sample-api-refract.json
@@ -1,0 +1,226 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "attributes": {
+        "meta": [
+          {
+            "element": "member",
+            "meta": {
+              "classes": [
+                "user"
+              ]
+            },
+            "content": {
+              "key": {
+                "element": "string",
+                "content": "FORMAT"
+              },
+              "value": {
+                "element": "string",
+                "content": "1A"
+              }
+            }
+          }
+        ]
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": "Messages"
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": "Message"
+              },
+              "attributes": {
+                "href": "/messages/{id}",
+                "hrefVariables": {
+                  "element": "hrefVariables",
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "description": "Id of a message"
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "id"
+                        },
+                        "value": {
+                          "element": "enum",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "1"
+                            },
+                            {
+                              "element": "string",
+                              "content": "2"
+                            },
+                            {
+                              "element": "string",
+                              "content": "3"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "content": [
+                {
+                  "element": "dataStructure",
+                  "content": [
+                    {
+                      "element": "object",
+                      "meta": {
+                        "id": "Message"
+                      },
+                      "content": [
+                        {
+                          "element": "member",
+                          "content": {
+                            "key": {
+                              "element": "string",
+                              "content": "id"
+                            },
+                            "value": {
+                              "element": "number"
+                            }
+                          }
+                        },
+                        {
+                          "element": "member",
+                          "meta": {
+                            "description": "The Message"
+                          },
+                          "content": {
+                            "key": {
+                              "element": "string",
+                              "content": "message"
+                            },
+                            "value": {
+                              "element": "string",
+                              "content": "Hello World!"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "Retrieve Message"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "200",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "dataStructure",
+                              "content": [
+                                {
+                                  "element": "Message"
+                                }
+                              ]
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": "messageBody"
+                              },
+                              "attributes": {
+                                "contentType": "application/json"
+                              },
+                              "content": "{\n  \"id\": 0,\n  \"message\": \"Hello World!\"\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "Delete Message"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "DELETE"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "204"
+                          },
+                          "content": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/parser-ast-test.coffee
+++ b/test/parser-ast-test.coffee
@@ -17,7 +17,7 @@ describe 'Blueprint AST', ->
     ### Message [/message{id}]
     '''
 
-    protagonist.parse source, (err, result) ->
+    protagonist.parse source, type: 'ast', (err, result) ->
       return done err if err
       ast = result.ast
 

--- a/test/parser-mson-test.coffee
+++ b/test/parser-mson-test.coffee
@@ -28,14 +28,17 @@ describe 'MSON Refract', ->
     it 'are defined', ->
       assert.isDefined attributes
 
+    it 'are a data structure', ->
+      assert.equal attributes.element, 'dataStructure'
+
     it 'are an object', ->
-      assert.equal attributes.element, 'object'
+      assert.equal attributes.content[0].element, 'object'
 
     it 'object has a single member', ->
-      assert.equal attributes.content.length, 1
+      assert.equal attributes.content[0].content.length, 1
 
     it 'member is `id`', ->
-      assert.equal attributes.content[0].content.key.content, 'id'
+      assert.equal attributes.content[0].content[0].content.key.content, 'id'
 
   describe 'Data structures', ->
     it 'are defined', ->
@@ -45,7 +48,7 @@ describe 'MSON Refract', ->
       assert.equal dataStructures.length, 1
 
     it 'item is a `Person` structure', ->
-      assert.equal dataStructures[0].meta.id, 'Person'
+      assert.equal dataStructures[0].content[0].meta.id, 'Person'
 
     it 'Person has a `name` member', ->
-      assert.equal dataStructures[0].content[0].content.key.content, 'name'
+      assert.equal dataStructures[0].content[0].content[0].content.key.content, 'name'

--- a/test/parser-mson-test.coffee
+++ b/test/parser-mson-test.coffee
@@ -18,7 +18,7 @@ describe 'MSON Refract', ->
     + name
     '''
 
-    protagonist.parse source, (err, result) ->
+    protagonist.parse source, type: 'ast', (err, result) ->
       return done err if err
       attributes = result.ast.content[0].content[0].actions[0].examples[0].responses[0].content[0]
       dataStructures = result.ast.content[1].content

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -1,0 +1,27 @@
+fs = require 'fs'
+path = require 'path'
+{assert} = require 'chai'
+protagonist = require '../build/Release/protagonist'
+
+describe "Parser Refract - Async", ->
+
+  refract_fixture = require './fixtures/sample-api-refract.json'
+  refract_parsed = null
+
+  # Read & parse blueprint fixture
+  before (done) ->
+
+    fixture_path = path.join __dirname, './fixtures/sample-api.apib'
+
+    fs.readFile fixture_path, 'utf8', (err, data) ->
+      return done err if err
+
+      protagonist.parse data, (err, result) ->
+        return done err if err
+
+        refract_parsed = result
+        done()
+
+  # Parser AST should conform to AST serialization JSON media type
+  it 'conforms to the refract spec', ->
+    assert.deepEqual refract_parsed, refract_fixture

--- a/test/sourcemap-test.coffee
+++ b/test/sourcemap-test.coffee
@@ -16,7 +16,7 @@ describe "Parser sourcemap", ->
     fs.readFile fixture_path, 'utf8', (err, data) ->
       return done err if err
 
-      protagonist.parse data, { exportSourcemap: true }, (err, result) ->
+      protagonist.parse data, { type: 'ast', exportSourcemap: true }, (err, result) ->
         return done err if err
 
         sourcemap_parsed = result.sourcemap

--- a/test/sync-test.coffee
+++ b/test/sync-test.coffee
@@ -16,7 +16,7 @@ describe "Parser AST - Sync", ->
     fs.readFile fixture_path, 'utf8', (err, data) ->
       return done err if err
 
-      ast_parsed = protagonist.parseSync(data).ast
+      ast_parsed = protagonist.parseSync(data, type: 'ast').ast
       done()
 
   # Parser AST should conform to AST serialization JSON media type


### PR DESCRIPTION
This work-in-progress change updates the interface of protagonist to accept
a new option called `type` which can have a value of either `ast` or `refract`
to output either the current API Blueprint AST or refract elements. Usage:

```js
protagonist.parse(blueprint, {type: 'ast'}, callback);
protagonist.parse(blueprint, {type: 'refract'}, callback);
```

Invalid values are handled but the option currently has no effect. Once
implemented in C++ Drafter the two `TODO` statements should be completed.

Note 1: It's not entirely clear how Drafter will return refract elements (will it use the same `ast` key in the result?). We may need to make small modifications to [src/result.cc](https://github.com/apiaryio/protagonist/blob/master/src/result.cc#L49) once Drafter is ready.

Note 2: #78 should be merged first to get tests passing.