### PR TITLE
Show AppVeyor badge for master in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 # Protagonist
 
 [![Circle CI](https://circleci.com/gh/apiaryio/protagonist.svg?style=shield)](https://circleci.com/gh/apiaryio/protagonist)
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/uaa6ivk97urmoucr?svg=true)](https://ci.appveyor.com/project/Apiary/protagonist)
-
-
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/uaa6ivk97urmoucr/branch/master?svg=true)](https://ci.appveyor.com/project/Apiary/protagonist)
 
 ### API Blueprint Parser for Node.js
 Protagonist is a Node.js wrapper for the [Snow Crash](https://github.com/apiaryio/snowcrash) library.


### PR DESCRIPTION
Currently the badge is showing the failing state for our branches.

![screen shot 2015-08-04 at 14 36 41](https://cloud.githubusercontent.com/assets/44164/9060682/3d74475c-3ab6-11e5-8997-0e1b9106c1a8.png)
