### PR TITLE
Prep experimental refract release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "0.20.1",
+  "version": "0.20.1-refract2",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",


### PR DESCRIPTION
This updates to the latest Drafter commit and preps for another experimental tagged refract release.