### PR TITLE
Improve Result::WrapResult

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
 script: "npm install && npm test"
 before_install:
   - git submodule update --init --recursive
-  - ruby -e "\`npm i -g npm\` if '`npm -v`'<'2.0.0'"
+  - ruby -e "\`npm i -g npm@2\` if '`npm -v`'<'2.0.0'"
 notifications:
   email:
     recipients:

--- a/src/annotation.cc
+++ b/src/annotation.cc
@@ -1,5 +1,6 @@
 #include "protagonist.h"
-#include "Serialize.h"
+#include "SerializeResult.h"
+#include "v8_wrapper.h"
 
 using namespace v8;
 using namespace protagonist;
@@ -36,32 +37,9 @@ NAN_METHOD(SourceAnnotation::New)
     NanReturnValue(args.This());
 }
 
-static Local<Object> WrapSourceCharactersRange(const mdp::CharactersRange& range)
-{
-    Local<Object> rangeObject = NanNew<Object>();
-
-    rangeObject->Set(NanNew<String>("index"), NanNew<Number>(range.location));
-    rangeObject->Set(NanNew<String>("length"), NanNew<Number>(range.length));
-    return rangeObject;
-}
-
 Local<Object> SourceAnnotation::WrapSourceAnnotation(const snowcrash::SourceAnnotation& annotation)
 {
-    Local<Function> cons = NanNew<Function>(constructor);
-    Local<Object> annotationWrap = cons->NewInstance();
+    sos::Object annotationObject = drafter::WrapAnnotation(annotation);
 
-    annotationWrap->Set(NanNew<String>("code"), NanNew<Number>(annotation.code));
-    annotationWrap->Set(NanNew<String>("message"), NanNew<String>(annotation.message.c_str()));
-
-    Local<Object> location = NanNew<Array>(annotation.location.size());
-    size_t i = 0;
-    for (mdp::CharactersRangeSet::const_iterator it = annotation.location.begin();
-         it != annotation.location.end();
-         ++it, ++i) {
-
-        location->Set(i, WrapSourceCharactersRange(*it));
-    }
-
-    annotationWrap->Set(NanNew<String>("location"), location);
-    return annotationWrap;
+    return v8_wrap(annotationObject)->ToObject();
 }

--- a/src/parse_async.cc
+++ b/src/parse_async.cc
@@ -118,13 +118,13 @@ void AsyncParseAfter(uv_work_t* request) {
     const unsigned argc = 2;
     Local<Value> argv[argc];
 
+    argv[1] = Result::WrapResult(baton->parseResult, baton->options, baton->astType);
+
     // Error Object
     if (baton->parseResult.report.error.code == snowcrash::Error::OK)
         argv[0] = NanNull();
     else
         argv[0] = SourceAnnotation::WrapSourceAnnotation(baton->parseResult.report.error);
-
-    argv[1] = Result::WrapResult(baton->parseResult, baton->options, baton->astType);
 
     TryCatch try_catch;
     Local<Function> callback = NanNew<Function>(baton->callback);

--- a/src/parse_sync.cc
+++ b/src/parse_sync.cc
@@ -51,10 +51,12 @@ NAN_METHOD(protagonist::ParseSync) {
     snowcrash::ParseResult<snowcrash::Blueprint> parseResult;
     drafter::ParseBlueprint(*sourceData, options, parseResult);
 
+    Local<Object> result = Result::WrapResult(parseResult, options, astType);
+
     if (parseResult.report.error.code != snowcrash::Error::OK) {
         NanThrowError(SourceAnnotation::WrapSourceAnnotation(parseResult.report.error));
         NanReturnUndefined();
     }
 
-    NanReturnValue(Result::WrapResult(parseResult, options, astType));
+    NanReturnValue(result);
 }

--- a/src/protagonist.h
+++ b/src/protagonist.h
@@ -48,7 +48,7 @@ namespace protagonist {
 
         // Wraps snowcrash::Warnings and snowcrash:Blueprint into report object
         // Note: snowcrash::Result::Error is being sent separately as Error object
-        static v8::Local<v8::Object> WrapResult(const snowcrash::ParseResult<snowcrash::Blueprint>& parseResult,
+        static v8::Local<v8::Object> WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& parseResult,
                                                 const snowcrash::BlueprintParserOptions& options,
                                                 const drafter::ASTType& astType);
 

--- a/src/result.cc
+++ b/src/result.cc
@@ -55,16 +55,15 @@ v8::Local<v8::Object> Result::WrapResult(snowcrash::ParseResult<snowcrash::Bluep
         parseResult.report.error = error;
     }
 
-    if (parseResult.report.error.code != snowcrash::Error::OK) {
+    if (astType == drafter::NormalASTType && parseResult.report.error.code != snowcrash::Error::OK) {
         result.set(AstKey, sos::Null());
 
         if ((options & snowcrash::ExportSourcemapOption) != 0) {
             result.set(SourcemapKey, sos::Null());
         }
     }
-    else {
-        result.unset(ErrorKey);
-    }
+
+    result.unset(ErrorKey);
 
     return v8_wrap(result)->ToObject();
 }

--- a/src/result.cc
+++ b/src/result.cc
@@ -1,6 +1,5 @@
 #include "protagonist.h"
-#include "SerializeAST.h"
-#include "SerializeSourcemap.h"
+#include "SerializeResult.h"
 #include "v8_wrapper.h"
 #include "snowcrash.h"
 
@@ -43,49 +42,22 @@ v8::Local<v8::Object> Result::WrapResult(const snowcrash::ParseResult<snowcrash:
                                          const snowcrash::BlueprintParserOptions& options,
                                          const drafter::ASTType& astType)
 {
-    Local<Function> cons = NanNew<Function>(constructor);
-    Local<Object> resultWrap = cons->NewInstance();
-
     static const char* AstKey = "ast";
-    static const char* WarningsKey = "warnings";
+    static const char* ErrorKey = "error";
     static const char* SourcemapKey = "sourcemap";
 
-    if (astType == drafter::RefractASTType) {
-      // The Refract output contains all the warnings and source map info, so
-      // we can just wrap and return the parse result.
-      sos::Object blueprintSerializationWrap = drafter::WrapParseResult(parseResult, options);
+    sos::Object result = drafter::WrapResult(parseResult, options, astType);
 
-      return v8_wrap(blueprintSerializationWrap)->ToObject();
+    if (parseResult.report.error.code != snowcrash::Error::OK) {
+        result.set(AstKey, sos::Null());
+
+        if ((options & snowcrash::ExportSourcemapOption) != 0) {
+            result.set(SourcemapKey, sos::Null());
+        }
+    }
+    else {
+        result.unset(ErrorKey);
     }
 
-    if (parseResult.report.error.code == snowcrash::Error::OK) {
-        sos::Object blueprintSerializationWrap = drafter::WrapBlueprint(parseResult.node, astType);
-
-        resultWrap->Set(NanNew<String>(AstKey), v8_wrap(blueprintSerializationWrap));
-    }
-    else
-        resultWrap->Set(NanNew<String>(AstKey), NanNull());
-
-    Local<Object> warnings = NanNew<Array>(parseResult.report.warnings.size());
-    size_t i = 0;
-
-    for (snowcrash::Warnings::const_iterator it = parseResult.report.warnings.begin();
-         it != parseResult.report.warnings.end();
-         ++it, ++i) {
-
-        warnings->Set(i, SourceAnnotation::WrapSourceAnnotation(*it));
-    }
-
-    resultWrap->Set(NanNew<String>(WarningsKey), warnings);
-
-    // Set source map only if requested
-    if (parseResult.report.error.code == snowcrash::Error::OK && (options & snowcrash::ExportSourcemapOption) != 0) {
-        sos::Object sourcemapSerializationWrap = drafter::WrapBlueprintSourcemap(parseResult.sourceMap);
-
-        resultWrap->Set(NanNew<String>(SourcemapKey), v8_wrap(sourcemapSerializationWrap));
-    }
-    else
-        resultWrap->Set(NanNew<String>(SourcemapKey), NanNull());
-
-    return resultWrap;
+    return v8_wrap(result)->ToObject();
 }

--- a/src/result.cc
+++ b/src/result.cc
@@ -38,7 +38,7 @@ NAN_METHOD(Result::New)
     NanReturnValue(args.This());
 }
 
-v8::Local<v8::Object> Result::WrapResult(const snowcrash::ParseResult<snowcrash::Blueprint>& parseResult,
+v8::Local<v8::Object> Result::WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& parseResult,
                                          const snowcrash::BlueprintParserOptions& options,
                                          const drafter::ASTType& astType)
 {
@@ -46,7 +46,14 @@ v8::Local<v8::Object> Result::WrapResult(const snowcrash::ParseResult<snowcrash:
     static const char* ErrorKey = "error";
     static const char* SourcemapKey = "sourcemap";
 
-    sos::Object result = drafter::WrapResult(parseResult, options, astType);
+    sos::Object result;
+
+    try {
+        result = drafter::WrapResult(parseResult, options, astType);
+    }
+    catch (snowcrash::Error& error) {
+        parseResult.report.error = error;
+    }
 
     if (parseResult.report.error.code != snowcrash::Error::OK) {
         result.set(AstKey, sos::Null());


### PR DESCRIPTION
This PR does the following:

* Optimizes `Result::WrapResult` so that it directly takes result from `drafter::WrapResult` instead of implementing `drafter::WrapResult` again.
* Safeguards against exceptions thrown during expansion and rendering of drafter.
* Optimizes `SourceAnnotation` class by using `drafter::WrapAnnotation`
* Updates the drafter submodule.

Blocked by apiaryio/drafter#131 and the submodule needs to be updated once that is merged.