### PR TITLE
Bump version for patch release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",


### PR DESCRIPTION
This fixes #100 by doing a patch release. The problem with the 1.1.0 release appears to be a packaging issue with the submodules. I needed to reset and clean all my submodules to get things working in my local checkout again.

You can try the package I will be releasing here:

```sh
npm install https://www.dropbox.com/s/5w4i49vf8yazpfs/protagonist-1.1.1.tgz?dl=1
```