### PR TITLE
Release 1.2.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0-beta.3",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",

--- a/scripts/cleanup
+++ b/scripts/cleanup
@@ -1,8 +1,15 @@
 var fs = require('fs');
 
 var ignoreFile = __dirname + "/../drafter/.npmignore";
-var ignoreTargetFile = __dirname + "/.ignore";
+var ignoreTargetFile = __dirname + "/.npmignore";
+
+var packageFile = __dirname + "/../drafter/package.json";
+var packageTargetFile = __dirname + "/package.json";
 
 if (fs.existsSync(ignoreTargetFile)) {
   fs.renameSync(ignoreTargetFile, ignoreFile);
+}
+
+if (fs.existsSync(packageTargetFile)) {
+  fs.renameSync(packageTargetFile, packageFile);
 }

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -1,8 +1,15 @@
 var fs = require('fs');
 
 var ignoreFile = __dirname + "/../drafter/.npmignore";
-var ignoreTargetFile = __dirname + "/.ignore";
+var ignoreTargetFile = __dirname + "/.npmignore";
+
+var packageFile = __dirname + "/../drafter/package.json";
+var packageTargetFile = __dirname + "/package.json";
 
 if (fs.existsSync(ignoreFile)) {
   fs.renameSync(ignoreFile, ignoreTargetFile);
+}
+
+if (fs.existsSync(packageFile)) {
+  fs.renameSync(packageFile, packageTargetFile);
 }


### PR DESCRIPTION
This release fixes a packaging problem causing the previous release to be un-installable.

---

The previous version (1.2.0-beta.2) was broken due to packaging while drafter's (via submodule) `package.json` file existed. During packaging, npm wouldn't copy `drafter/drafter.gyp` into the release tarball and subsequently caused the release tarball to be un-installable.

This PR moves package.json away during packaging, this is a short term solution and as a long term solution I think we should instead move drafter's JS components into another repository (perhaps protagonist_pure if that Ruby/Python convention applies to Node).

I've confirmed that these changes work, and you can too:

```shell
$ npm pack
> protagonist@1.2.0-beta.3 prepublish /Users/kyle/Projects/apiaryio/protagonist
> node scripts/prepublish
protagonist-1.2.0-beta.3.tgz

$ npm install protagonist-1.2.0-beta.3.tgz
\
> protagonist@1.2.0-beta.3 install /Users/kyle/Projects/apiaryio/protagonist/node_modules/protagonist
> node-gyp rebuild
...
  CXX(target) Release/obj.target/protagonist/src/parse_async.o
  CXX(target) Release/obj.target/protagonist/src/parse_sync.o
  CXX(target) Release/obj.target/protagonist/src/protagonist.o
  CXX(target) Release/obj.target/protagonist/src/result.o
  CXX(target) Release/obj.target/protagonist/src/v8_wrapper.o
  SOLINK_MODULE(target) Release/protagonist.node
protagonist@1.2.0-beta.3 node_modules/protagonist

$
```