### PR TITLE
Release 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "1.2.0-beta.3",
+  "version": "1.2.0",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",

--- a/test/fixtures/sample-api-refract.json
+++ b/test/fixtures/sample-api-refract.json
@@ -176,7 +176,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"


### PR DESCRIPTION
This update now uses Drafter 2.0.0. Please see [Drafter 2.0.0](https://github.com/apiaryio/drafter/releases/tag/v2.0.0) for the list of changes.