### PR TITLE
Rename exportSourcemap to generateSourceMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Options can be passed to the parser as an optional second argument to both the a
 
 ```js
 var options = {
-    exportSourcemap: true
+    generateSourceMap: true
 }
 protagonist.parse('# My API', options, callback);
 ```
@@ -60,7 +60,7 @@ The available options are:
 Name                   | Description
 ---------------------- | ----------------------------------------------------------
 `requireBlueprintName` | Require parsed blueprints have a title (default: false)
-`exportSourcemap`      | Enable sourcemap generation (default: false)
+`generateSourceMap`    | Enable sourcemap generation (default: false)
 `type`                 | Set the output structure type as either `ast` or `refract` (default: `refract`)
 
 ### Parsing Result

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",

--- a/src/options_parser.cc
+++ b/src/options_parser.cc
@@ -7,6 +7,7 @@ using namespace protagonist;
 //static const std::string RenderDescriptionsOptionKey = "renderDescriptions";
 static const std::string RequireBlueprintNameOptionKey = "requireBlueprintName";
 static const std::string ExportSourcemapOptionKey = "exportSourcemap";
+static const std::string GenerateSourceMapOptionKey = "generateSourceMap";
 static const std::string TypeOptionKey = "type";
 
 static const std::string TypeOptionAst = "ast";
@@ -35,7 +36,7 @@ OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject) {
             else
                 optionsResult->options &= snowcrash::RequireBlueprintNameOption;
         }
-        else if (ExportSourcemapOptionKey == *strKey) {
+        else if (ExportSourcemapOptionKey == *strKey || GenerateSourceMapOptionKey == *strKey) {
             // ExportSourcemapOption
             if (value->IsTrue())
                 optionsResult->options |= snowcrash::ExportSourcemapOption;
@@ -64,7 +65,7 @@ OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject) {
             std::stringstream ss;
             ss << "unrecognized option '" << *strKey << "', expected: ";
             ss << "'" << RequireBlueprintNameOptionKey << "', '";
-            ss << ExportSourcemapOptionKey << "' or '" << TypeOptionKey << '"';
+            ss << GenerateSourceMapOptionKey << "' or '" << TypeOptionKey << '"';
 
             optionsResult->error = ss.str().c_str();
             return optionsResult;

--- a/test/sourcemap-test.coffee
+++ b/test/sourcemap-test.coffee
@@ -16,6 +16,29 @@ describe "Parser sourcemap", ->
     fs.readFile fixture_path, 'utf8', (err, data) ->
       return done err if err
 
+      protagonist.parse data, { type: 'ast', generateSourceMap: true }, (err, result) ->
+        return done err if err
+
+        sourcemap_parsed = result.sourcemap
+        done()
+
+  # Parser Sourcemap should conform to recent source map serialization JSON media type
+  it '`sourcemap` field conforms to `vnd.apiblueprint.sourcemap+json; version=4.0`', ->
+    assert.deepEqual sourcemap_fixture, sourcemap_parsed
+
+describe "Parser sourcemap with old option name", ->
+
+  sourcemap_fixture = require './fixtures/sample-api-sourcemap.json'
+  sourcemap_parsed = null
+
+  # Read & parse blueprint fixture
+  before (done) ->
+
+    fixture_path = path.join __dirname, './fixtures/sample-api.apib'
+
+    fs.readFile fixture_path, 'utf8', (err, data) ->
+      return done err if err
+
       protagonist.parse data, { type: 'ast', exportSourcemap: true }, (err, result) ->
         return done err if err
 

--- a/tools/protagonist.js
+++ b/tools/protagonist.js
@@ -29,7 +29,7 @@ if (typeof args == 'undefined' || args.length !== 1) {
 fs.readFile(args[0], 'utf8', function (err, data) {
   if (err) throw err;
 
-  protagonist.parse(data, {exportSourcemap: true}, function (err, result) {
+  protagonist.parse(data, {generateSourceMap: true}, function (err, result) {
     if (err) {
         console.log(JSON.stringify(err, null, 2));
         process.exit(err.code);


### PR DESCRIPTION
According to this discussion, https://github.com/apiaryio/fury-adapter-swagger/issues/26#issuecomment-164501633

Please note that `exportSourcemap` is still supported to make the library backward compatibility.