### PR TITLE
Add npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+circle.yml
+appveyor.yml
+Vagrantfile
+Dockerfile
+provisioning.sh
+scripts/
+drafter/emcc/
+drafter/tools/
+drafter/*.xc*
+drafter/features
+drafter/Gemfile*
+drafter/test/
+build/


### PR DESCRIPTION
This PR ignores many files including drafter's tests and emscripten code from the final NPM package for protagonist. Along with ignoring build artifacts from the `build` directory. Overall this substantially decreases the package size from 3.0MB to 1.3MB.

```shell
$ du -h protagonist-1.2.5*
1.3M	protagonist-1.2.5-ignored.tgz
3.0M	protagonist-1.2.5-master.tgz
```