### PR TITLE
Release 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",


### PR DESCRIPTION
This update now uses Drafter 2.2.0. Please see [Drafter 2.2.0](https://github.com/apiaryio/drafter/releases/tag/v2.2.0) for the list of changes.