### PR TITLE
Release 1.3.0-pre.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "1.2.6",
+  "version": "1.3.0-pre.0",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",

--- a/test/fixtures/sample-api-refract.json
+++ b/test/fixtures/sample-api-refract.json
@@ -193,7 +193,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"number\"\n    },\n    \"message\": {\n      \"type\": \"string\",\n      \"description\": \"The Message\"\n    }\n  }\n}"
                             }


### PR DESCRIPTION
This pull request updates to Drafter 2.3.0-pre.0 and releases Protagonist as 1.3.0-pre.0.

### Changelog

This update now uses Drafter 2.3.0-pre.0. Please see [Drafter 2.3.0-pre.0](https://github.com/apiaryio/drafter/releases/tag/v2.3.0-pre.0) for the list of changes.