### PR TITLE
Always on sourcemaps for drafter errors to get them

### DIFF
--- a/src/parse_async.cc
+++ b/src/parse_async.cc
@@ -105,7 +105,7 @@ void AsyncParse(uv_work_t* request) {
     snowcrash::ParseResult<snowcrash::Blueprint> parseResult;
 
     // Parse the source data
-    drafter::ParseBlueprint(baton->sourceData, baton->options, parseResult);
+    drafter::ParseBlueprint(baton->sourceData, baton->options | snowcrash::ExportSourcemapOption, parseResult);
 
     baton->parseResult = parseResult;
 }

--- a/src/parse_sync.cc
+++ b/src/parse_sync.cc
@@ -49,7 +49,7 @@ NAN_METHOD(protagonist::ParseSync) {
 
     // Parse the source data
     snowcrash::ParseResult<snowcrash::Blueprint> parseResult;
-    drafter::ParseBlueprint(*sourceData, options, parseResult);
+    drafter::ParseBlueprint(*sourceData, options | snowcrash::ExportSourcemapOption, parseResult);
 
     Local<Object> result = Result::WrapResult(parseResult, options, astType);
 


### PR DESCRIPTION
We should have done this when we switched it on in drafter.

If we had a clean public API, we should not need to do this.