### PR TITLE
WrapResult in the thread not on event loop

### DIFF
--- a/src/parse_sync.cc
+++ b/src/parse_sync.cc
@@ -1,5 +1,6 @@
 #include <string>
 #include <sstream>
+#include "v8_wrapper.h"
 #include "protagonist.h"
 #include "snowcrash.h"
 #include "drafter.h"
@@ -51,7 +52,7 @@ NAN_METHOD(protagonist::ParseSync) {
     snowcrash::ParseResult<snowcrash::Blueprint> parseResult;
     drafter::ParseBlueprint(*sourceData, options | snowcrash::ExportSourcemapOption, parseResult);
 
-    Local<Object> result = Result::WrapResult(parseResult, options, astType);
+    Local<Object> result = v8_wrap(Result::WrapResult(parseResult, options, astType))->ToObject();
 
     if (parseResult.report.error.code != snowcrash::Error::OK) {
         Nan::ThrowError((Local<Value>) SourceAnnotation::WrapSourceAnnotation(parseResult.report.error));

--- a/src/protagonist.h
+++ b/src/protagonist.h
@@ -48,9 +48,9 @@ namespace protagonist {
 
         // Wraps snowcrash::Warnings and snowcrash:Blueprint into report object
         // Note: snowcrash::Result::Error is being sent separately as Error object
-        static v8::Local<v8::Object> WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& parseResult,
-                                                const snowcrash::BlueprintParserOptions& options,
-                                                const drafter::ASTType& astType);
+        static sos::Object WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& parseResult,
+                                      const snowcrash::BlueprintParserOptions& options,
+                                      const drafter::ASTType& astType);
 
     private:
         Result();

--- a/src/result.cc
+++ b/src/result.cc
@@ -1,6 +1,5 @@
 #include "protagonist.h"
 #include "SerializeResult.h"
-#include "v8_wrapper.h"
 #include "snowcrash.h"
 
 using namespace v8;
@@ -38,9 +37,9 @@ NAN_METHOD(Result::New)
     info.GetReturnValue().Set(info.This());
 }
 
-v8::Local<v8::Object> Result::WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& parseResult,
-                                         const snowcrash::BlueprintParserOptions& options,
-                                         const drafter::ASTType& astType)
+sos::Object Result::WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& parseResult,
+                               const snowcrash::BlueprintParserOptions& options,
+                               const drafter::ASTType& astType)
 {
     static const char* AstKey = "ast";
     static const char* ErrorKey = "error";
@@ -65,5 +64,5 @@ v8::Local<v8::Object> Result::WrapResult(snowcrash::ParseResult<snowcrash::Bluep
 
     result.unset(ErrorKey);
 
-    return v8_wrap(result)->ToObject();
+    return result;
 }

--- a/test/async-test.coffee
+++ b/test/async-test.coffee
@@ -1,0 +1,21 @@
+fs = require 'fs'
+path = require 'path'
+protagonist = require '../build/Release/protagonist'
+{assert} = require 'chai'
+
+describe 'Parser async parse', ->
+
+  it 'will finish after the sync', (done) ->
+
+    syncFinished = false
+    sync_parsed = null
+    data = fs.readFileSync(path.join(__dirname, './fixtures/sample-api.apib'), 'utf8')
+    protagonist.parse data, (err, res) ->
+      if syncFinished
+        assert.deepEqual res, sync_parsed
+        done()
+      else
+        done new Error('Async finished before sync')
+
+    sync_parsed = protagonist.parseSync(data)
+    syncFinished = true


### PR DESCRIPTION
Once we cleanup the Drafter API Protagonist needs an overhaul on how things are done.