### PR TITLE
Update nan to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=0.8.15"
   },
   "dependencies": {
-    "nan": "~2.0.9"
+    "nan": "~2.2.1"
   },
   "devDependencies": {
     "coffee-script": "~1.6.0",


### PR DESCRIPTION
Apparently nan 2.0.9 is not good enough for node v5.