### PR TITLE
Make it clear that ast is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Name                   | Description
 `generateSourceMap`    | Enable sourcemap generation (default: false)
 `type`                 | Set the output structure type as either `ast` or `refract` (default: `refract`)
 
+**NOTE**: *The `ast` option is deprecated in favour of `refract`.*
+
 ### Parsing Result
 
 Parsing this blueprint:


### PR DESCRIPTION
Just want to explicitly mention that the `ast` option is deprecated.