### PR TITLE
Release 1.5.0-pre.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Protagonist Changelog
 
+## 1.5.0-pre.0
+
+This update now uses Drafter 3.1.0-pre.0. Please see [Drafter
+3.1.0-pre.0](https://github.com/apiaryio/drafter/releases/tag/v3.1.0-pre.0) for
+the list of changes.
+
 ## 1.4.1
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "1.4.1",
+  "version": "1.5.0-pre.0",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",


### PR DESCRIPTION
This update now uses Drafter 3.1.0-pre.0. Please see [Drafter 3.1.0-pre.0](https://github.com/apiaryio/drafter/releases/tag/v3.1.0-pre.0) for the list of changes.