### PR TITLE
Release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Protagonist Changelog
 
-## Master
+## 1.5.2
 
 This update now uses Drafter 3.1.3. Please see [Drafter
 3.1.3](https://github.com/apiaryio/drafter/releases/tag/v3.1.3) for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+This update now uses Drafter 3.1.3. Please see [Drafter
+3.1.3](https://github.com/apiaryio/drafter/releases/tag/v3.1.3) for
+the list of changes.
+
 ## 1.5.1
 
 This update now uses Drafter 3.1.2. Please see [Drafter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",


### PR DESCRIPTION
This update now uses Drafter 3.1.3. Please see [Drafter 3.1.3](https://github.com/apiaryio/drafter/releases/tag/v3.1.3) for the list of changes.