### PR TITLE
chore(ci): Test on Node 7 and drop Node 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: false
 language: node_js
 node_js:
+- '7'
 - '6'
 - '4'
 - '0.12'
 - '0.10'
-- '0.8'
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm install protagonist
 
 **NOTE:** *Installing Protagonist depends on having Python 2 installed along with a compiler such as GCC, Clang or MSVC.*
 
-Tested with node.js ~0.8.15, 0.10.x, 0.12.x, 4, 6
+Tested with node.js 0.10.x, 0.12.x, 4, 6, 7
 
 ## Getting started
 


### PR DESCRIPTION
I don't see any reason test against Node 0.8, it is extremely old and not even mentioned on NodeJS LTS list: https://github.com/nodejs/LTS.

This PR adds testing against Node 7.