### PR TITLE
Update to drafter 3.2.5 and release 1.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Protagonist Changelog
 
+## 1.6.6
+
+This update now uses Drafter 3.2.5. Please see [Drafter
+3.2.5](https://github.com/apiaryio/drafter/releases/tag/v3.2.5) for
+the list of changes.
+
 ## 1.6.5
 
 This update now uses Drafter 3.2.4. Please see [Drafter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",


### PR DESCRIPTION
This update now uses Drafter 3.2.5. Please see [Drafter 3.2.5](https://github.com/apiaryio/drafter/releases/tag/v3.2.5) for the list of changes.