### PR TITLE
Remove unused typedef

### DIFF
--- a/src/refractToV8.cc
+++ b/src/refractToV8.cc
@@ -150,7 +150,6 @@ Local<Object> v8ValueList(const T& e, bool sourcemap)
 
 Local<Value> v8RefElement(const RefElement& e, bool sourcemap)
 {
-    typedef RefElement::ValueType::const_iterator iterator;
     Local<Object> obj = v8Element(e, sourcemap);
 
     obj->Set(v8_string("content"), v8_string(e.value));


### PR DESCRIPTION
This remove a compilation warning because the typedef is not used:

```
../src/refractToV8.cc:153:51: warning: unused typedef 'iterator' [-Wunused-local-typedef]
    typedef RefElement::ValueType::const_iterator iterator;
```