### PR TITLE
Use isolate version of TryCatch

### DIFF
--- a/src/parse_async.cc
+++ b/src/parse_async.cc
@@ -129,12 +129,12 @@ void AsyncParseAfter(uv_work_t* request) {
         argv[0] = annotations2v8(baton->result);
     }
 
-    TryCatch try_catch;
+    TryCatch try_catch(v8::Isolate::GetCurrent());
     Local<Function> callback = Nan::New<Function>(baton->callback);
     callback->Call(Nan::GetCurrentContext()->Global(), argc, argv);
 
     if (try_catch.HasCaught()) {
-        node::FatalException(try_catch);
+        node::FatalException(v8::Isolate::GetCurrent(), try_catch);
     }
 
     baton->callback.Reset();

--- a/src/validate_async.cc
+++ b/src/validate_async.cc
@@ -141,12 +141,12 @@ void AsyncValidateAfter(uv_work_t* request) {
         }
     }
 
-    TryCatch try_catch;
+    TryCatch try_catch(v8::Isolate::GetCurrent());
     Local<Function> callback = Nan::New<Function>(baton->callback);
     callback->Call(Nan::GetCurrentContext()->Global(), argc, argv);
 
     if (try_catch.HasCaught()) {
-        node::FatalException(try_catch);
+        node::FatalException(v8::Isolate::GetCurrent(), try_catch);
     }
 
     baton->callback.Reset();


### PR DESCRIPTION
Previous APIs were deprecated and causing deprecation warnings

```
  CXX(target) Release/obj.target/protagonist/src/parse_async.o
../src/parse_async.cc:132:14: warning: 'TryCatch' is deprecated [-Wdeprecated-declarations]
    TryCatch try_catch;
             ^
/Users/kyle/.node-gyp/8.4.0/include/node/v8.h:8157:40: note: 'TryCatch' has been explicitly marked deprecated here
  V8_DEPRECATED("Use isolate version", TryCatch());
                                       ^
../src/parse_async.cc:137:15: warning: 'FatalException' is deprecated: Use FatalException(isolate, ...) [-Wdeprecated-declarations]
        node::FatalException(try_catch);
              ^
/Users/kyle/.node-gyp/8.4.0/include/node/node.h:339:29: note: 'FatalException' has been explicitly marked deprecated here
                inline void FatalException(const v8::TryCatch& try_catch) {
                            ^
2 warnings generated.
                                                  ^
1 warning generated.
  CXX(target) Release/obj.target/protagonist/src/validate_async.o
../src/validate_async.cc:144:14: warning: 'TryCatch' is deprecated [-Wdeprecated-declarations]
    TryCatch try_catch;
             ^
/Users/kyle/.node-gyp/8.4.0/include/node/v8.h:8157:40: note: 'TryCatch' has been explicitly marked deprecated here
  V8_DEPRECATED("Use isolate version", TryCatch());
                                       ^
../src/validate_async.cc:149:15: warning: 'FatalException' is deprecated: Use FatalException(isolate, ...) [-Wdeprecated-declarations]
        node::FatalException(try_catch);
              ^
/Users/kyle/.node-gyp/8.4.0/include/node/node.h:339:29: note: 'FatalException' has been explicitly marked deprecated here
                inline void FatalException(const v8::TryCatch& try_catch) {
                            ^
2 warnings generated.
  CXX(target) Release/obj.target/protagonist/src/validate_sync.o
  SOLINK_MODULE(target) Release/protagonist.node
gyp info okay
```