### PR TITLE
Test parsing all drafter fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
     "async": "^2.4.1",
     "chai": "^3.5.0",
     "coffee-script": "~1.6.0",
+    "glob": "^7.1.2",
     "mocha": "^3.4.1"
   },
   "scripts": {
-    "test": "mocha --compilers coffee:coffee-script -R spec ./test/*-test.coffee"
+    "test": "mocha --compilers coffee:coffee-script -R spec test"
   },
   "license": "MIT"
 }

--- a/test/fixtures-test.js
+++ b/test/fixtures-test.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const expect = require('chai').expect;
+const glob = require('glob');
+
+const protagonist = require('../build/Release/protagonist');
+
+describe('Parsing Drafter Test Fixtures', () => {
+  const fixtures = glob.sync('drafter/test/fixtures/*/*.apib');
+
+  fixtures.forEach((fixture) => {
+    it(`parsing ${fixture}`, () => {
+      const source = fs.readFileSync(fixture, 'utf-8');
+      const parseResult = protagonist.parseSync(source);
+    });
+  });
+});

--- a/test/fixtures-test.js
+++ b/test/fixtures-test.js
@@ -8,6 +8,15 @@ describe('Parsing Drafter Test Fixtures', () => {
   const fixtures = glob.sync('drafter/test/fixtures/*/*.apib');
 
   fixtures.forEach((fixture) => {
+    if (fixture.match(/\/mson\//) !== null) {
+      return;
+    }
+
+    // TODO: Remove these exceptions after they are fixed in drafter
+    if (fixture === 'drafter/test/fixtures/render/nullable.apib' || fixture === 'drafter/test/fixtures/schema/enum-nullable.apib') {
+      return;
+    }
+
     it(`parsing ${fixture}`, () => {
       // Find the parse result fixture(s).
       // Some test fixtures are with source maps and others are not.

--- a/test/fixtures-test.js
+++ b/test/fixtures-test.js
@@ -9,8 +9,29 @@ describe('Parsing Drafter Test Fixtures', () => {
 
   fixtures.forEach((fixture) => {
     it(`parsing ${fixture}`, () => {
+      // Find the parse result fixture(s).
+      // Some test fixtures are with source maps and others are not.
+      const results = glob.sync(fixture.replace('.apib', '{.sourcemap,}.json'));
+      const sourceMapResult = results.find((results) => results.includes('.sourcemap.json'))
+      const result = results.find((results) => !results.includes('.sourcemap.json'))
+
       const source = fs.readFileSync(fixture, 'utf-8');
-      const parseResult = protagonist.parseSync(source);
+
+      if (result) {
+        const parseResult = protagonist.parseSync(source);
+        const expected = JSON.parse(fs.readFileSync(result, 'utf-8'));
+        expect(parseResult).to.deep.equal(expected);
+      }
+
+      if (sourceMapResult) {
+        const sourceMapParseResult = protagonist.parseSync(source, {generateSourceMap: true});
+        const sourceMapExpected = JSON.parse(fs.readFileSync(sourceMapResult, 'utf-8'));
+        expect(sourceMapParseResult).to.deep.equal(sourceMapExpected);
+      }
+
+      if (!result && !sourceMapResult) {
+        throw Error('No parse result fixture found');
+      }
     });
   });
 });


### PR DESCRIPTION
This pull request adds a new set of tests which test that all of the test fixtures can be parsed. The first commit just handles parsing, the second commit handles comparing the result against the test fixtures depending on if there is source maps or not for the fixture.

This is worrying as I actually found some discrepancies and the tests do fail.