### PR TITLE
Test on macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,17 @@ jobs:
           root: ~/repo
           paths: .
 
+  test-macos:
+    working_directory: ~/repo
+    macos:
+      xcode: "9.4.0"
+
+    steps:
+      - checkout
+      - run: git submodule update --init --recursive
+      - run: npm install
+      - run: npm test
+
   publish:
     <<: *defaults
     steps:
@@ -40,9 +51,11 @@ workflows:
   test-publish:
     jobs:
       - test
+      - test-macos
       - publish:
           requires:
             - test
+            - test-macos
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
As we've discovered macOS only while producing https://github.com/apiaryio/protagonist/pull/205 I think it makes sense to add CI build on macOS specifically so we can catch these types of problems on CI.