### PR TITLE
Remove unused include headers from protagonist target

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,11 +7,6 @@
       "target_name": "protagonist",
       "include_dirs": [
         "drafter/src",
-        "drafter/ext/snowcrash/src",
-        "drafter/ext/snowcrash/ext/markdown-parser/src",
-        "drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/src",
-        "drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/html",
-        "drafter/ext/sos/src",
         "<!(node -e \"require('nan')\")"
       ],
       "sources": [


### PR DESCRIPTION
Protagonist itself doesn't depend on snow crash or sos and therefore shouldn't include its headers. It depends on drafter, and drafter utilises those headers within the libdrafter target.