### PR TITLE
update: fix reported crash in option parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Protagonist Changelog
 
+## master
+
+### Bug fixes
+
+* Fixed segfault while parsing options 
+
 ## 2.0.0-pre.2
 
 This update now uses Drafter 4.0.0-pre.2. Please see [Drafter

--- a/src/options_parser.cc
+++ b/src/options_parser.cc
@@ -35,9 +35,12 @@ OptionsResult* protagonist::ParseOptionsObject(Handle<Object> optionsObject, boo
 
     for (uint32_t i = 0 ; i < length ; ++i) {
         const Local<Value> key = properties->Get(i);
-        const Local<Value> value = optionsObject->Get(key);
-
         const String::Utf8Value strKey(key);
+
+        v8::MaybeLocal<v8::Value> maybeValue = optionsObject->Get(Nan::GetCurrentContext(), key);
+
+        // all options are boolean w/ false value default
+        const Local<Value> value = maybeValue.FromMaybe(Local<Value>(False(Isolate::GetCurrent())));
 
         if (RequireBlueprintNameOptionKey == *strKey) {
             optionsResult->parseOptions.requireBlueprintName = value->IsTrue();

--- a/test/protagonist-options-crash-test.js
+++ b/test/protagonist-options-crash-test.js
@@ -1,0 +1,15 @@
+const protagonist = require('./helpers/protagonist');
+
+const path = require('path');
+const fs = require('fs');
+const valid_fixture = fs.readFileSync(path.join(__dirname, 'fixtures', 'valid.apib'), 'utf8');
+const expect = require('chai').expect;
+const assert = require('chai').assert;
+
+describe('Protagonist option vulerability', () => {
+  it('should not segfault protagonist', () => {
+      assert.throws(() => {
+        protagonist.parse(valid_fixture, { get requireBlueprintName() { throw 'nope' }});
+      }, 'nope')
+  })
+})


### PR DESCRIPTION
Reported issue in the latest version of Protagonist causes 
a segfault (from an unchecked null pointer) in the native addon (C++) code. 


Fixed by replacing calls to deprecated V8 API methods with their safer replacements. 
  Local< Value > Get(Local< Value > key))
  MaybeLocal< Value > Get (Local< Context > context, Local< Value > key)
and to perform check on the resulting MaybeLocal<> value.
