### PR TITLE
Document validate and async APIs, clarify installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,155 @@
 ![logo](https://raw.github.com/apiaryio/api-blueprint/master/assets/logo_apiblueprint.png)
 
-# Protagonist
+# Protagonist - API Blueprint Parser for Node.js
 
 [![Circle CI](https://circleci.com/gh/apiaryio/protagonist.svg?style=shield)](https://circleci.com/gh/apiaryio/protagonist)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/uaa6ivk97urmoucr/branch/master?svg=true)](https://ci.appveyor.com/project/Apiary/protagonist)
 
-### API Blueprint Parser for Node.js
-Protagonist is a Node.js wrapper for the [Drafter](https://github.com/apiaryio/drafter) library.
-
-API Blueprint is Web API documentation language. You can find API Blueprint documentation on the [API Blueprint site](https://apiblueprint.org).
+Protagonist is a Node.js wrapper for the
+[Drafter](https://github.com/apiaryio/drafter), an API Blueprint parser. [API
+Blueprint](https://apiblueprint.org) is a language for describing web APIs.
 
 ## Install
 
 **NOTE:** *For general use we recommend that you use the [Drafter
 NPM](https://github.com/apiaryio/drafter-npm) package instead of Protagonist
 directly as Protagonist needs to be compiled which may not be possible in every
-situation*
+situation.*
 
-The best way to install Protagonist is by using its [NPM package](https://npmjs.org/package/protagonist).
+Protagonist can be installed via the [Protagonist npm
+package](https://npmjs.org/package/protagonist) by
+[npm](https://docs.npmjs.com/cli/npm) or [yarn](https://yarnpkg.com/en/).
 
 ```sh
 $ npm install protagonist
+# or
+$ yarn install protagonist
 ```
 
-**NOTE:** *Installing Protagonist depends on having Python 2 installed along with a compiler such as GCC, Clang or MSVC.*
+Protagonist uses the
+[node-gyp](https://github.com/nodejs/node-gyp#installation) build tool which
+requires Python 2.7 (3.x is not supported) along with a compiler and other
+build tools. Take a look at their installation steps for
+[Linux](https://github.com/nodejs/node-gyp#on-unix),
+[macOS](https://github.com/nodejs/node-gyp#on-macos), and
+[Windows](https://github.com/nodejs/node-gyp#on-windows).
 
-Tested with node.js 4, 6, 7
+## Usage
 
-## Getting started
+Protagonist offers the ability to both validate, and parse an API Blueprint.
+It offers the following APIs:
+
+- [`validate(source, options)`](#validate)
+- [`validateSync(source, options)`](#validate-sync)
+- [`parse(source, options)`](#parse)
+- [`parseSync(source, options)`](#parse-sync)
+
+**NOTE:** *It is not recommended to use the synchronous APIs as they can block
+the Node.JS event loop.*
+
+<a name="validate"></a>
+### Validating an API Blueprint
+
+You can validate an API Blueprint to determine if the source is a valid
+document. The parse result will contain any errors or warnings that the
+document would emit during parsing.
 
 ```js
-var protagonist = require('protagonist');
+const protagonist = require('protagonist');
 
-protagonist.parse('# My API', function(error, result) {
-    if (error) {
-        console.log(error);
-        return;
-    }
-
-    console.log(result);
-});
+const parseResult = await protagonist.parse('# My API');
+console.log(JSON.stringify(parseResult, null, 2));
 ```
 
-### Synchronous usage
-
-If you for some reason need to use the API synchronously, that is also possible.
-Please note that the recommended way is to use the asynchronous API as to not
-block the event loop.
+or by using Promises:
 
 ```js
-var result = protagonist.parseSync('# My API');
+const protagonist = require('protagonist');
+
+protagonist.validate('# My API')
+  .then((parseResult) => {
+    console.log(JSON.stringify(parseResult, null, 2));
+  })
+  .catch((error) => {
+    console.error(error);
+  });
 ```
 
-### Parsing Options
+See the [parse result](#parse-result) section below for more information about
+the structure of the parse result.
+
+<a name="validate-sync"></a>
+#### Synchronous API
+
+```js
+const protagonist = require('protagonist');
+const parseResult = protagonist.validateSync('# My API');
+```
+
+#### Validation Options
 
 Options can be passed to the parser as an optional second argument to both the asynchronous and synchronous interfaces:
 
 ```js
-var options = {
-    generateSourceMap: true
-}
-protagonist.parse('# My API', options, callback);
+const protagonist = require('protagonist');
+
+const options = {
+  requireBlueprintName: true,
+};
+const parseResult = await protagonist.validate('# My API', options);
+```
+
+The available options are:
+
+Name                   | Description
+---------------------- | ----------------------------------------------------------
+`requireBlueprintName` | Require parsed blueprints have a title (default: false)
+
+<a name="parse"></a>
+### Parsing an API Blueprint
+
+You can parse an API Blueprint with async/await:
+
+```js
+const protagonist = require('protagonist');
+
+const parseResult = await protagonist.parse('# My API');
+console.log(JSON.stringify(parseResult, null, 2));
+```
+
+or by using Promises:
+
+```js
+const protagonist = require('protagonist');
+
+protagonist.parse('# My API')
+  .then((parseResult) => {
+    console.log(JSON.stringify(parseResult, null, 2));
+  })
+  .catch((error) => {
+    console.error(error);
+  });
+```
+
+See the [parse result](#parse-result) section below for more information about
+the structure of the parse result.
+
+<a name="parse-sync"></a>
+#### Synchronous API
+
+```js
+const parseResult = protagonist.parseSync('# My API');
+```
+
+#### Parsing Options
+
+Options can be passed to the parser as an optional second argument to both the asynchronous and synchronous interfaces:
+
+```js
+const options = {
+  generateSourceMap: true,
+};
+const parseResult = await protagonist.parse('# My API', options);
 ```
 
 The available options are:
@@ -70,16 +159,26 @@ Name                   | Description
 `requireBlueprintName` | Require parsed blueprints have a title (default: false)
 `generateSourceMap`    | Enable sourcemap generation (default: false)
 
-### Parsing Result
+<a name="parse-result"></a>
+### Parse Result
 
-Parsing this blueprint:
+The format of the parse result is an [API Elements](https://apielements.org/)
+structure, there is also [API Elements:
+JS](https://github.com/apiaryio/api-elements.js) which contains tooling to
+handle this format in JavaScript. It is recommended to use the provided API
+Elements tooling to [prevent any tight
+coupling](http://apielements.org/en/latest/overview.html#consuming-documents)
+between your tool and a parse result.
+
+As an example, parsing the following API Blueprint:
 
 ```apib
 # GET /
 + Response 204
 ```
 
-will produce the following object (`result` variable):
+Would result in the following [API Elements Parse
+Result](http://apielements.org/en/latest/element-definitions.html#parse-result-element-types):
 
 ```json
 {
@@ -162,42 +261,27 @@ will produce the following object (`result` variable):
 }
 ```
 
-## Hacking Protagonist
-You are welcome to contribute. Use following steps to build & test Protagonist.
+## Developing Protagonist
 
-### Build
-Protagonist uses [node-gyp](https://github.com/TooTallNate/node-gyp) build tool.
-
-1. If needed, install node-gyp:
-
-    ```sh
-    $ npm install -g node-gyp
-    ```
-
-2. Clone the repository, and fetch the submodules:
-
-    ```sh
-    $ git clone --recursive git://github.com/apiaryio/protagonist.git
-    $ cd protagonist
-    $ npm install
-    ```
-
-3. Build:
-
-    ```sh
-    $ node-gyp configure
-    $ node-gyp build
-    ```
-
-### Test
-Inside the protagonist repository run:
+You can use the following steps to build and test Protagonist.
 
 ```sh
+$ git clone --recursive https://github.com/apiaryio/protagonist.git
+$ cd protagonist
+$ npm install
+```
+
+While iterating on the package, you can use `npm run build` to compile
+Protagonist:
+
+```sh
+$ npm run build
 $ npm test
 ```
 
-### Contribute
-Fork & Pull Request.
+Protagonist is built using [node-gyp](https://github.com/nodejs/node-gyp), you
+can consult their documentation for further information on the build system.
 
 ## License
+
 MIT License. See the [LICENSE](https://github.com/apiaryio/protagonist/blob/master/LICENSE) file.


### PR DESCRIPTION
I've rehauled the README a bit, documenting the async APIs and validation APIs clearly. I've also changed the installation instructions to guide uses to the node-gyp information as that is clearer, and also contains exact dependencies and steps for example installing build tools on Windows. I've also made it clearer on what the output parse result format is and encouraged users to use the API Elements tooling.

It can be read as rendered markdown at https://github.com/apiaryio/protagonist/blob/30e18e593fdc162581feb30626960677cfb2426e/README.md