### PR TITLE
fix(package): udpate node-gyp to v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
     "node": ">=4"
   },
   "dependencies": {
-    "nan": "^2.12.1",
-    "node-gyp": "^3.8.0"
+    "nan": "^2.12.1"
   },
   "devDependencies": {
     "async": "^2.6.1",
     "chai": "^4.1.2",
     "glob": "^7.1.2",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "node-gyp": "^4.0.0"
   },
   "scripts": {
     "build": "node-gyp build",


### PR DESCRIPTION
To avoid tar vulnerability as per https://nodesecurity.io/advisories/803