### PR TITLE
Add support for Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+- '12'
 - '11'
 - '10'
 - '8'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=4"
   },
   "dependencies": {
-    "nan": "^2.12.1"
+    "nan": "^2.13.2"
   },
   "devDependencies": {
     "async": "^2.6.1",

--- a/src/parse_async.cc
+++ b/src/parse_async.cc
@@ -178,7 +178,7 @@ NAN_METHOD(protagonist::Parse)
     drafter_serialize_options serializeOptions = { false, DRAFTER_SERIALIZE_JSON };
 
     if (optionIndex) {
-        OptionsResult* optionsResult = ParseOptionsObject(Handle<Object>::Cast(info[optionIndex]), false);
+        OptionsResult* optionsResult = ParseOptionsObject(Local<Object>::Cast(info[optionIndex]), false);
 
         if (optionsResult->error != NULL) {
             Nan::ThrowTypeError(optionsResult->error);

--- a/src/parse_sync.cc
+++ b/src/parse_sync.cc
@@ -9,6 +9,7 @@ using namespace protagonist;
 
 NAN_METHOD(protagonist::ParseSync) {
     Nan::HandleScope scope;
+    Local<Context> context = Nan::GetCurrentContext();
 
     // Check arguments
     if (info.Length() != 1 && info.Length() != 2) {
@@ -27,14 +28,14 @@ NAN_METHOD(protagonist::ParseSync) {
     }
 
     // Get source data
-    Nan::Utf8String sourceData(info[0]->ToString());
+    Nan::Utf8String sourceData(info[0]->ToString(context).ToLocalChecked());
 
     // Prepare options
     drafter_parse_options parseOptions = {false};
     drafter_serialize_options serializeOptions = {false, DRAFTER_SERIALIZE_JSON};
 
     if (info.Length() == 2) {
-        OptionsResult *optionsResult = ParseOptionsObject(Handle<Object>::Cast(info[1]), false);
+        OptionsResult *optionsResult = ParseOptionsObject(info[1]->ToObject(context).ToLocalChecked(), false);
 
         if (optionsResult->error != NULL) {
             Nan::ThrowTypeError(optionsResult->error);

--- a/src/protagonist.cc
+++ b/src/protagonist.cc
@@ -3,18 +3,19 @@
 using namespace v8;
 using namespace protagonist;
 
-void Init(Handle<Object> exports) {
+void Init(Local<Object> exports) {
+    Local<Context> context = Nan::GetCurrentContext();
 
     // parse function
-    exports->Set(Nan::New<String>("parse").ToLocalChecked(), Nan::New<FunctionTemplate>(Parse)->GetFunction());
+    exports->Set(context, Nan::New<String>("parse").ToLocalChecked(), Nan::New<FunctionTemplate>(Parse)->GetFunction(context).ToLocalChecked());
 
     // parseSync function
-    exports->Set(Nan::New<String>("parseSync").ToLocalChecked(), Nan::New<FunctionTemplate>(ParseSync)->GetFunction());
+    exports->Set(context, Nan::New<String>("parseSync").ToLocalChecked(), Nan::New<FunctionTemplate>(ParseSync)->GetFunction(context).ToLocalChecked());
 
     // validate function
-    exports->Set(Nan::New<String>("validate").ToLocalChecked(), Nan::New<FunctionTemplate>(Validate)->GetFunction());
+    exports->Set(context, Nan::New<String>("validate").ToLocalChecked(), Nan::New<FunctionTemplate>(Validate)->GetFunction(context).ToLocalChecked());
     // validateSync function
-    exports->Set(Nan::New<String>("validateSync").ToLocalChecked(), Nan::New<FunctionTemplate>(ValidateSync)->GetFunction());
+    exports->Set(context, Nan::New<String>("validateSync").ToLocalChecked(), Nan::New<FunctionTemplate>(ValidateSync)->GetFunction(context).ToLocalChecked());
 }
 
 NODE_MODULE(protagonist, Init)

--- a/src/protagonist.h
+++ b/src/protagonist.h
@@ -17,7 +17,7 @@ namespace protagonist {
       char *error;
     };
 
-    OptionsResult* ParseOptionsObject(v8::Handle<v8::Object>, bool);
+    OptionsResult* ParseOptionsObject(v8::Local<v8::Object>, bool);
     void FreeOptionsResult(OptionsResult** optionsResult);
 
     //

--- a/src/validate_async.cc
+++ b/src/validate_async.cc
@@ -162,7 +162,7 @@ NAN_METHOD(protagonist::Validate)
     drafter_parse_options parseOptions = { false };
 
     if (optionIndex) {
-        OptionsResult* optionsResult = ParseOptionsObject(Handle<Object>::Cast(info[optionIndex]), true);
+        OptionsResult* optionsResult = ParseOptionsObject(Local<Object>::Cast(info[optionIndex]), true);
 
         if (optionsResult->error != NULL) {
             Nan::ThrowTypeError(optionsResult->error);

--- a/src/validate_sync.cc
+++ b/src/validate_sync.cc
@@ -9,6 +9,7 @@ using namespace protagonist;
 
 NAN_METHOD(protagonist::ValidateSync) {
     Nan::HandleScope scope;
+    Local<Context> context = Nan::GetCurrentContext();
 
     // Check arguments
     if (info.Length() != 1 && info.Length() != 2) {
@@ -27,13 +28,13 @@ NAN_METHOD(protagonist::ValidateSync) {
     }
 
     // Get source data
-    Nan::Utf8String sourceData(info[0]->ToString());
+    Nan::Utf8String sourceData(info[0]->ToString(context).ToLocalChecked());
 
     // Prepare options
     drafter_parse_options parseOptions = {false};
 
     if (info.Length() == 2) {
-        OptionsResult *optionsResult = ParseOptionsObject(Handle<Object>::Cast(info[1]), true);
+        OptionsResult *optionsResult = ParseOptionsObject(Local<Object>::Cast(info[1]), true);
 
         if (optionsResult->error != NULL) {
             Nan::ThrowTypeError(optionsResult->error);


### PR DESCRIPTION
Recently I have update Node to 12 through Homebrew on my Mac and notice the build of protagonist is broken, It seems like Node 12 removed the deprecated `v8::Handle` as following errors.

I get some hints from https://github.com/nodejs/nan/issues/849, Read the docs of [nan](https://github.com/nodejs/nan/tree/master/doc), and then try to fix it myself.

```
$ uname -a
Darwin Gasols-MacBook-Pro.local 18.5.0 Darwin Kernel Version 18.5.0: Mon Mar 11 20:40:32 PDT 2019; root:xnu-4903.251.3~3/RELEASE_X86_64 x86_64
$ node -v
v12.1.0

$ npm run build
gyp info it worked if it ends with ok
gyp info using node-gyp@4.0.0
gyp info using node@12.1.0 | darwin | x64
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]

  ............... SKIP ..................

  CXX(target) Release/obj.target/protagonist/src/options_parser.o
In file included from ../src/options_parser.cc:2:
../src/protagonist.h:20:43: error: no member named 'Handle' in namespace 'v8'
    OptionsResult* ParseOptionsObject(v8::Handle<v8::Object>, bool);
                                      ~~~~^
../src/protagonist.h:20:60: error: expected '(' for function-style cast or type construction
    OptionsResult* ParseOptionsObject(v8::Handle<v8::Object>, bool);
                                                 ~~~~~~~~~~^
../src/protagonist.h:20:61: error: expected expression
    OptionsResult* ParseOptionsObject(v8::Handle<v8::Object>, bool);
                                                            ^
../src/protagonist.h:20:67: error: expected '(' for function-style cast or type construction
    OptionsResult* ParseOptionsObject(v8::Handle<v8::Object>, bool);
                                                              ~~~~^

  ............... SKIP ..................

10 errors generated.
make: *** [Release/obj.target/protagonist/src/options_parser.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/gasolwu/Code/protagonist/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:196:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:256:12)
gyp ERR! System Darwin 18.5.0
gyp ERR! command "/usr/local/Cellar/node/12.1.0/bin/node" "/Users/gasolwu/Code/protagonist/node_modules/.bin/node-gyp" "build"
gyp ERR! cwd /Users/gasolwu/Code/protagonist
gyp ERR! node -v v12.1.0
gyp ERR! node-gyp -v v4.0.0
gyp ERR! not ok
```