### PR TITLE
Remove Node 11 from CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: node_js
 node_js:
 - '12'
-- '11'
 - '10'
 - '8'
 - '6'


### PR DESCRIPTION
Since we are testing on Node 12 (LTS) we can skip Node 11 as we usually skip odd numered Node versions if there is a higher Node stable.