### PR TITLE
Update to Drafter 3.0.0 pre.6 (and release Protagonist 2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+This update now uses Drafter 4.0.0-pre.6. Please see [Drafter
+4.0.0-pre.6](https://github.com/apiaryio/drafter/releases/tag/v4.0.0-pre.6) for
+the list of changes.
+
 ### Enhancements
 
 - Added support for Node 12.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Protagonist Changelog
 
-## Master
+## 2.0.0-pre.9 (2019-05-20)
 
 This update now uses Drafter 4.0.0-pre.6. Please see [Drafter
 4.0.0-pre.6](https://github.com/apiaryio/drafter/releases/tag/v4.0.0-pre.6) for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Protagonist Changelog
 
+## Master
+
+### Enhancements
+
+- Added support for Node 12.
+
 ## 2.0.0-pre.8 (2019-05-09)
 
 This is a re-release of Protagonist 2.0.0-pre.7 due to problems with NPM

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "2.0.0-pre.8",
+  "version": "2.0.0-pre.9",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",


### PR DESCRIPTION
I've also added a changelog entry for https://github.com/apiaryio/protagonist/pull/233 which made it into this release.