### PR TITLE
Align with nan example

### DIFF
--- a/src/protagonist.cc
+++ b/src/protagonist.cc
@@ -3,19 +3,18 @@
 using namespace v8;
 using namespace protagonist;
 
-void Init(Local<Object> exports) {
-    Local<Context> context = Nan::GetCurrentContext();
+NAN_MODULE_INIT(InitAll) {
+    Nan::Set(target, Nan::New<String>("parse").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(Parse)).ToLocalChecked());
 
-    // parse function
-    exports->Set(context, Nan::New<String>("parse").ToLocalChecked(), Nan::New<FunctionTemplate>(Parse)->GetFunction(context).ToLocalChecked());
+    Nan::Set(target, Nan::New<String>("parseSync").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(ParseSync)).ToLocalChecked());
 
-    // parseSync function
-    exports->Set(context, Nan::New<String>("parseSync").ToLocalChecked(), Nan::New<FunctionTemplate>(ParseSync)->GetFunction(context).ToLocalChecked());
+    Nan::Set(target, Nan::New<String>("validate").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(Validate)).ToLocalChecked());
 
-    // validate function
-    exports->Set(context, Nan::New<String>("validate").ToLocalChecked(), Nan::New<FunctionTemplate>(Validate)->GetFunction(context).ToLocalChecked());
-    // validateSync function
-    exports->Set(context, Nan::New<String>("validateSync").ToLocalChecked(), Nan::New<FunctionTemplate>(ValidateSync)->GetFunction(context).ToLocalChecked());
+    Nan::Set(target, Nan::New<String>("validateSync").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(ValidateSync)).ToLocalChecked());
 }
 
-NODE_MODULE(protagonist, Init)
+NODE_MODULE(protagonist, InitAll)


### PR DESCRIPTION
This PR prevents the following warnings being emitted when building Protagonist:

```
  CXX(target) Release/obj.target/protagonist/src/protagonist.o
../src/protagonist.cc:10:5: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
    exports->Set(context, Nan::New<String>("parse").ToLocalChecked(), Nan::New<FunctionTemplate>(Parse)->GetFunction(context).ToLocalChecked());
    ^~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/protagonist.cc:13:5: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
    exports->Set(context, Nan::New<String>("parseSync").ToLocalChecked(), Nan::New<FunctionTemplate>(ParseSync)->GetFunction(context).ToLocalChecked());
    ^~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/protagonist.cc:16:5: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
    exports->Set(context, Nan::New<String>("validate").ToLocalChecked(), Nan::New<FunctionTemplate>(Validate)->GetFunction(context).ToLocalChecked());
    ^~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/protagonist.cc:18:5: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
    exports->Set(context, Nan::New<String>("validateSync").ToLocalChecked(), Nan::New<FunctionTemplate>(ValidateSync)->GetFunction(context).ToLocalChecked());
    ^~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
4 warnings generated.
```

I've altered the entrypoint of the module to match that of the Nan example (https://github.com/nodejs/nan/blob/2ee313aaca52e2b478965ac50eb5082520380d1b/examples/async_pi_estimate/addon.cc).