### PR TITLE
Reflect changes in drafter C API

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,6 +10,8 @@
         "<!(node -e \"require('nan')\")"
       ],
       "sources": [
+        "src/options.cc",
+        "src/options.h",
         "src/options_parser.cc",
         "src/parse_async.cc",
         "src/parse_sync.cc",

--- a/src/options.cc
+++ b/src/options.cc
@@ -1,0 +1,53 @@
+#include "options.h"
+
+#include <cassert>
+
+#include "drafter.h"
+
+using namespace protagonist;
+
+namespace
+{
+    void ensure_parse_options(parse_options_ptr& opts) noexcept
+    {
+        if (!opts) {
+            opts.reset(drafter_init_parse_options());
+        }
+    }
+}  // namespace
+
+void parse_options_deleter::operator()(drafter_parse_options* obj) noexcept
+{
+    drafter_free_parse_options(obj);
+}
+
+Options::Options() noexcept
+    : parse_options_{nullptr}, serialize_sourcemaps_{false}
+{
+}
+
+const drafter_parse_options* Options::parseOptions() const noexcept
+{
+    return parse_options_.get();
+}
+
+parse_options_ptr Options::claimParseOptions() noexcept
+{
+    return std::move(parse_options_);
+}
+
+void Options::setSerializeSourcemaps() noexcept
+{
+    serialize_sourcemaps_ = true;
+}
+
+bool Options::serializeSourcemaps() const noexcept
+{
+    return serialize_sourcemaps_;
+}
+
+void Options::setNameRequired() noexcept
+{
+    ensure_parse_options(parse_options_);
+    drafter_set_name_required(parse_options_.get());
+}

--- a/src/options.h
+++ b/src/options.h
@@ -1,0 +1,35 @@
+#ifndef OPTIONS_H
+#define OPTIONS_H
+
+#include <memory>
+
+struct drafter_parse_options;
+
+namespace protagonist
+{
+    struct parse_options_deleter {
+        void operator()(drafter_parse_options* obj) noexcept;
+    };
+
+    using parse_options_ptr =
+        std::unique_ptr<drafter_parse_options, parse_options_deleter>;
+
+    class Options
+    {
+        parse_options_ptr parse_options_;
+        bool serialize_sourcemaps_;
+
+       public:
+        Options() noexcept;
+
+        const drafter_parse_options* parseOptions() const noexcept;
+        void setNameRequired() noexcept;
+
+        bool serializeSourcemaps() const noexcept;
+        void setSerializeSourcemaps() noexcept;
+
+        parse_options_ptr claimParseOptions() noexcept;
+    };
+}  // namespace protagonist
+
+#endif

--- a/src/protagonist.h
+++ b/src/protagonist.h
@@ -1,24 +1,18 @@
 #ifndef PROTAGONIST_H
 #define PROTAGONIST_H
 
+#include <string>
+
 #include <node.h>
 #include <v8.h>
 #include "nan.h"
-#include "drafter.h"
 
 namespace protagonist {
 
-    //
-    // Options parsing
-    ///
-    struct OptionsResult {
-      drafter_parse_options parseOptions;
-      drafter_serialize_options serializeOptions;
-      char *error;
-    };
+    using ErrorMessage = std::string;
+    class Options;
 
-    OptionsResult* ParseOptionsObject(v8::Local<v8::Object>, bool);
-    void FreeOptionsResult(OptionsResult** optionsResult);
+    ErrorMessage ParseOptionsObject(Options&, v8::Local<v8::Object>, bool);
 
     //
     // Parse functions

--- a/src/refractToV8.cc
+++ b/src/refractToV8.cc
@@ -284,11 +284,11 @@ void v8Wrapper::operator()(const ObjectElement& e)
 }
 
 Local<Value> refract2v8(const IElement* res,
-                        drafter_serialize_options serializeOptions)
+                        bool sourceMaps)
 {
     assert(res);
 
-    v8Wrapper f(serializeOptions.sourcemap);
+    v8Wrapper f(sourceMaps);
     Visitor v(f);
     res->content(v);
 

--- a/src/refractToV8.h
+++ b/src/refractToV8.h
@@ -6,7 +6,7 @@
 #include <refract/ElementIfc.h>
 #include <drafter.h>
 
-v8::Local<v8::Value> refract2v8(const refract::IElement* res, drafter_serialize_options serializeOptions);
+v8::Local<v8::Value> refract2v8(const refract::IElement* res, bool sourceMaps);
 v8::Local<v8::Value> annotations2v8(const refract::IElement* res);
 
 #endif


### PR DESCRIPTION
See https://github.com/apiaryio/drafter/pull/766

Reflects changes in options handling of the drafter C API.

Before merging,

- [x]  drafter/tjanc/capi-hide-options must be merged to drafter/master,
- [x] the drafter submodule must point to drafter/master