### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Protagonist Changelog
 
+## 2.2.0 (2020-04-20)
+
+### Enhancements
+
+* Drafter contains two new options for disabling messageBody and
+  messageBodySchema generation from MSON. `generateMessageBody` and
+  `generatedMessageBodySchema` respectively.
+
 ## 2.1.0 (2020-03-17)
 
 This update now uses Drafter 5.0.0-rc.1. Please see [Drafter

--- a/README.md
+++ b/README.md
@@ -148,16 +148,20 @@ Options can be passed to the parser as an optional second argument to both the a
 ```js
 const options = {
   generateSourceMap: true,
+  generateMessageBody: true,
+  generateMessageBodySchema: true,
 };
 const parseResult = await protagonist.parse('# My API', options);
 ```
 
 The available options are:
 
-Name                   | Description
----------------------- | ----------------------------------------------------------
-`requireBlueprintName` | Require parsed blueprints have a title (default: false)
-`generateSourceMap`    | Enable sourcemap generation (default: false)
+Name                        | Description
+--------------------------- | ----------------------------------------------------------
+`requireBlueprintName`      | Require parsed blueprints have a title (default: false)
+`generateSourceMap`         | Enable sourcemap generation (default: false)
+`generateMessageBody`       | Enable generation of messageBody from MSON (default: true)
+`generateMessageBodySchema` | Enable generation of messageBodySchema from MSON (default: true)
 
 <a name="parse-result"></a>
 ### Parse Result

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protagonist",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "API Blueprint Parser",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./build/Release/protagonist",


### PR DESCRIPTION
* Drafter contains two new options for disabling messageBody and messageBodySchema generation from MSON. `generateMessageBody` and `generatedMessageBodySchema` respectively.

I’ve updated the README documentation to match.
