### PR TITLE
Move smoke tests to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,25 +19,6 @@ jobs:
       - run: git submodule update --init --recursive
       - run: npm install
       - run: npm test
-      - persist_to_workspace:
-          root: ~/repo
-          paths: .
-
-  test-smoke:
-    <<: *defaults
-    working_directory: ~/
-    steps:
-      - attach_workspace:
-          at: ~/repo
-      - run:
-          working_directory: ~/repo
-          command: npm pack
-      - run:
-          name: Test Protagonist can be installed
-          command: npm install ./repo/protagonist-*.tgz
-      - run:
-          name: Test Protagonist can be used
-          command: node -e "assert(require('protagonist').parseSync('# My API').element === 'parseResult')"
 
   test-macos:
     working_directory: ~/repo
@@ -67,10 +48,6 @@ workflows:
   test-publish:
     jobs:
       - test: *tag-filter
-      - test-smoke:
-          <<: *tag-filter
-          requires:
-            - test
       - test-macos: *tag-filter
       - publish:
           requires:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,3 +16,18 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm install
       - run: npm test
+
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          path: protagonist
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm pack
+        working-directory: protagonist
+      - run: npm install ./protagonist/protagonist-*.tgz
+      - run: node -e "assert(require('protagonist').parseSync('# My API').element === 'parseResult')"


### PR DESCRIPTION
The smoke tests are designed to ensure that the package can be build correctly during install and that it can be used (simple parse). This ensures things like node-gyp are working correctly, and that all of the source files from the submodules for drafter are correctly in-place in the NPM package (else installation and parsing will fail).